### PR TITLE
[FIX] run_matlab_cmd now working with MATLAB on Linux

### DIFF
--- a/pysaliency/utils.py
+++ b/pysaliency/utils.py
@@ -301,6 +301,7 @@ def run_matlab_cmd(cmd, cwd=None):
     matlab = get_matlab_or_octave()
     args = []
     if os.path.basename(matlab).startswith('matlab'):
+        cmd = "cd('%s'); %s" % (cwd, cmd)
         args += ['-nodesktop', '-nosplash', '-r']
         args.append("try;{};catch exc;disp(getReport(exc));disp('__ERROR__');exit(1);end;quit".format(cmd))
     else:


### PR DESCRIPTION
Hi Matthias,

I tried to run your [demo code](https://pypi.org/project/pysaliency/) but the MATLAB call failed in `mit.py` at lines 119-125, saying that it couldn't find `extract_all_fixations`:

```
print('Running original code to extract fixations. This can take some minutes.')
print('Warning: In the IPython Notebook, the output is shown on the console instead of the notebook.')
with open(os.path.join(temp_dir, 'extract_all_fixations.m'), 'w') as f:
    for cmd in cmds:
        f.write('{}\n'.format(cmd))

run_matlab_cmd('extract_all_fixations;', cwd=temp_dir)
```

The problem is that, when running MATLAB on Linux, the `cwd` argument often has no effect when running the MATLAB command via subprocess.check_call in `utils.py`. This is because the startup folder of MATLAB on Linux is not always the directory from which you start it (see [here](https://de.mathworks.com/help/matlab/matlab_env/start-matlab-on-linux-platforms.html) for more information). So what most likely happened was that it started MATLAB from the temporary folder but it then used a different folder as a startup folder. And that folder did not contain the `extract_all_fixations.m` file.

I modified `run_matlab_cmd` so that MATLAB first cd's into the directory that contains the m file and _then_ executes the desired function. The demo code now runs as expected.

Cheers,
Michael



