### PR TITLE
fix rescaling bug in NUSEF

### DIFF
--- a/pysaliency/external_datasets/nusef.py
+++ b/pysaliency/external_datasets/nusef.py
@@ -140,7 +140,6 @@ def get_NUSEF_public(location=None):
 
                 if stimulus_name not in stimuli_indices:
                     # one of the non public images
-                    print("missing stimulus for", stimulus_name)
                     continue
 
                 if stimulus_name in IMAGES_WITH_ONLY_PUBLIC_SEGMENTATION_MASKS:
@@ -162,10 +161,12 @@ def get_NUSEF_public(location=None):
                 image_resize_factor = 768 / size[0]
                 resized_height = 768
                 resized_width = size[1] * image_resize_factor
+
                 if resized_width > 1024:
-                    image_resize_factor * (1024 / resized_width)
+                    additional_factor = (1024 / resized_width)
+                    image_resize_factor *= additional_factor
+                    resized_height *= additional_factor
                     resized_width = 1024
-                    resized_height *= (1024 / resized_width)
 
                 # images were shown centered
                 x_offset = (1024 - resized_width) / 2

--- a/tests/external_datasets/test_NUSEF.py
+++ b/tests/external_datasets/test_NUSEF.py
@@ -26,23 +26,23 @@ def test_NUSEF(location):
 
     assert len(fixations.x) == 66133
 
-    assert np.mean(fixations.x) == approx(452.88481928283653)
-    assert np.mean(fixations.y) == approx(337.03301271592267)
+    assert np.mean(fixations.x) == approx(461.73823151304873)
+    assert np.mean(fixations.y) == approx(336.54399742934976)
     assert np.mean(fixations.t) == approx(2.0420471776571456)
     assert np.mean(fixations.lengths) == approx(4.085887529675049)
 
-    assert np.std(fixations.x) == approx(187.61359889152612)
-    assert np.std(fixations.y) == approx(142.59867038067452)
+    assert np.std(fixations.x) == approx(191.71434262715272)
+    assert np.std(fixations.y) == approx(144.60874197688884)
     assert np.std(fixations.t) == approx(1.82140623534086)
     assert np.std(fixations.lengths) == approx(3.4339653884944963)
 
-    assert kurtosis(fixations.x) == approx(0.403419633086465)
-    assert kurtosis(fixations.y) == approx(2.0001760382566793)
+    assert kurtosis(fixations.x) == approx(0.29833124844005354)
+    assert kurtosis(fixations.y) == approx(1.9158192030098018)
     assert kurtosis(fixations.t) == approx(5285.812604733467)
     assert kurtosis(fixations.lengths) == approx(0.8320210638515699)
 
-    assert skew(fixations.x) == approx(0.42747360917257937)
-    assert skew(fixations.y) == approx(0.7441609934536769)
+    assert skew(fixations.x) == approx(0.3994141751115464)
+    assert skew(fixations.y) == approx(0.7246047287335385)
     assert skew(fixations.t) == approx(39.25751334379433)
     assert skew(fixations.lengths) == approx(0.9874139139443956)
 


### PR DESCRIPTION
I think it would be more elegant to simply compute the rescaling factor via the minimum of required x and y scaling, but for now I just fixed the bug. Also, it might be good to stick with how the matlab code does the rescaling.