### PR TITLE
Speedup baseline crossval

### DIFF
--- a/pysaliency/baseline_utils.py
+++ b/pysaliency/baseline_utils.py
@@ -369,8 +369,6 @@ class CrossvalMultipleRegularizations(object):
             verbose=False
         )
 
-        mean_area = np.mean([x[2]*x[3] for x in X_areas])
-        self.mean_area = mean_area
 
         self.X = fixations_to_scikit_learn(
             self.fixations,
@@ -378,8 +376,11 @@ class CrossvalMultipleRegularizations(object):
             keep_aspect=True, add_shape=False, add_fixation_number=True, verbose=False
         )
 
-        real_areas = [self.stimuli.sizes[n][0]*self.stimuli.sizes[n][1] for n in self.fixations.n]
-        areas_gold = [x[2]*x[3] for x in X_areas]
+        stimuli_sizes = np.array(self.stimuli.sizes)
+        real_areas = stimuli_sizes[self.fixations.n, 0] * stimuli_sizes[self.fixations.n, 1]
+        areas_gold = X_areas[:, 2] * X_areas[:, 3]
+        self.mean_area = np.mean(areas_gold)
+
         correction = np.log(areas_gold) - np.log(real_areas)
         self.regularization_log_likelihoods = []
 

--- a/tests/test_baseline_utils.py
+++ b/tests/test_baseline_utils.py
@@ -157,3 +157,4 @@ def test_crossval_multiple_regularizations(stimuli, fixation_trains):
 
     score = estimator.score(log_bandwidth, *log_regularizations)
     assert isinstance(score, float)
+    np.testing.assert_allclose(score, -1.4673831679692528e-10)


### PR DESCRIPTION
I noticed that fitting centerbiases for large datasets such as SALICON has a very long startup time. This is likely because CrossvalMultipleRegularizations iterates multiple times over each fixation. This PR changes the slow python loops to fast numpy loops.