### PR TITLE
Bugfix: create_subset returned wrong stimulus indices

### DIFF
--- a/pysaliency/datasets/__init__.py
+++ b/pysaliency/datasets/__init__.py
@@ -73,6 +73,7 @@ def create_subset(stimuli, fixations, stimuli_indices):
         new_image_indices = [new_pos[i] for i in fixations.scanpaths.n[scanpath_inds]]
 
         new_scanpaths = fixations.scanpaths[scanpath_inds]
+        new_scanpaths.n = np.array(new_image_indices)
 
         new_fixations = ScanpathFixations(
             scanpaths=new_scanpaths,

--- a/pysaliency/datasets/fixations.py
+++ b/pysaliency/datasets/fixations.py
@@ -309,8 +309,8 @@ class Fixations(object):
         """ Write fixations to hdf5 file or hdf5 group
         """
 
-        target.attrs['type'] = np.string_('Fixations')
-        target.attrs['version'] = np.string_('1.2')
+        target.attrs['type'] = np.bytes_('Fixations')
+        target.attrs['version'] = np.bytes_('1.2')
 
         variable_length_arrays = []
 
@@ -324,8 +324,8 @@ class Fixations(object):
                 data = data._data
             target.create_dataset(attribute, data=data)
 
-        target.attrs['__attributes__'] = np.string_(json.dumps(self.__attributes__))
-        target.attrs['__variable_length_arrays__'] = np.string_(json.dumps(sorted(variable_length_arrays)))
+        target.attrs['__attributes__'] = np.bytes_(json.dumps(self.__attributes__))
+        target.attrs['__variable_length_arrays__'] = np.bytes_(json.dumps(sorted(variable_length_arrays)))
 
     @classmethod
     @hdf5_wrapper(mode='r')
@@ -503,8 +503,8 @@ class ScanpathFixations(Fixations):
         """ Write ScanpathFixations to hdf5 file or hdf5 group
         """
 
-        target.attrs['type'] = np.string_('ScanpathFixations')
-        target.attrs['version'] = np.string_('1.0')
+        target.attrs['type'] = np.bytes_('ScanpathFixations')
+        target.attrs['version'] = np.bytes_('1.0')
 
         self.scanpaths.to_hdf5(target.create_group('scanpaths'))
 
@@ -1000,8 +1000,8 @@ class FixationTrains(ScanpathFixations):
         """ Write fixationtrains to hdf5 file or hdf5 group
         """
 
-        target.attrs['type'] = np.string_('FixationTrains')
-        target.attrs['version'] = np.string_('1.3')
+        target.attrs['type'] = np.bytes_('FixationTrains')
+        target.attrs['version'] = np.bytes_('1.3')
 
         variable_length_arrays = []
 
@@ -1016,19 +1016,19 @@ class FixationTrains(ScanpathFixations):
             target.create_dataset(attribute, data=data)
 
         saved_attributes = [attribute_name for attribute_name in self.__attributes__ if attribute_name not in self.auto_attributes]
-        target.attrs['__attributes__'] = np.string_(json.dumps(saved_attributes))
+        target.attrs['__attributes__'] = np.bytes_(json.dumps(saved_attributes))
 
-        target.attrs['scanpath_attribute_mapping'] = np.string_(json.dumps(self.scanpath_attribute_mapping))
+        target.attrs['scanpath_attribute_mapping'] = np.bytes_(json.dumps(self.scanpath_attribute_mapping))
 
         scanpath_attributes_group = target.create_group('scanpath_attributes')
         for attribute_name, attribute_value in self.scanpath_attributes.items():
             scanpath_attributes_group.create_dataset(attribute_name, data=attribute_value)
-        scanpath_attributes_group.attrs['__attributes__'] = np.string_(json.dumps(sorted(self.scanpath_attributes.keys())))
+        scanpath_attributes_group.attrs['__attributes__'] = np.bytes_(json.dumps(sorted(self.scanpath_attributes.keys())))
 
         scanpath_fixation_attributes_group = target.create_group('scanpath_fixation_attributes')
         for attribute_name, attribute_value in self.scanpath_fixation_attributes.items():
             scanpath_fixation_attributes_group.create_dataset(attribute_name, data=attribute_value._data)
-        scanpath_fixation_attributes_group.attrs['__attributes__'] = np.string_(json.dumps(sorted(self.scanpath_fixation_attributes.keys())))
+        scanpath_fixation_attributes_group.attrs['__attributes__'] = np.bytes_(json.dumps(sorted(self.scanpath_fixation_attributes.keys())))
 
 
     @classmethod

--- a/pysaliency/datasets/scanpaths.py
+++ b/pysaliency/datasets/scanpaths.py
@@ -118,8 +118,8 @@ class Scanpaths(object):
     def to_hdf5(self, target):
         """ Write scanpaths to hdf5 file or hdf5 group
         """
-        target.attrs['type'] = np.string_('Scanpaths')
-        target.attrs['version'] = np.string_('1.0')
+        target.attrs['type'] = np.bytes_('Scanpaths')
+        target.attrs['version'] = np.bytes_('1.0')
 
         target.create_dataset('xs', data=self.xs._data)
         target.create_dataset('ys', data=self.ys._data)
@@ -129,14 +129,14 @@ class Scanpaths(object):
         scanpath_attributes_group = target.create_group('scanpath_attributes')
         for attribute_name, attribute_value in self.scanpath_attributes.items():
             create_hdf5_dataset(scanpath_attributes_group, attribute_name, attribute_value)
-        scanpath_attributes_group.attrs['__attributes__'] = np.string_(json.dumps(sorted(self.scanpath_attributes.keys())))
+        scanpath_attributes_group.attrs['__attributes__'] = np.bytes_(json.dumps(sorted(self.scanpath_attributes.keys())))
 
         fixation_attributes_group = target.create_group('fixation_attributes')
         for attribute_name, attribute_value in self.fixation_attributes.items():
             fixation_attributes_group.create_dataset(attribute_name, data=attribute_value._data)
-        fixation_attributes_group.attrs['__attributes__'] = np.string_(json.dumps(sorted(self.fixation_attributes.keys())))
+        fixation_attributes_group.attrs['__attributes__'] = np.bytes_(json.dumps(sorted(self.fixation_attributes.keys())))
 
-        target.attrs['attribute_mapping'] = np.string_(json.dumps(self.attribute_mapping))
+        target.attrs['attribute_mapping'] = np.bytes_(json.dumps(self.attribute_mapping))
 
 
     @classmethod

--- a/pysaliency/datasets/stimuli.py
+++ b/pysaliency/datasets/stimuli.py
@@ -170,8 +170,8 @@ class Stimuli(Sequence):
         """ Write stimuli to hdf5 file or hdf5 group
         """
 
-        target.attrs['type'] = np.string_('Stimuli')
-        target.attrs['version'] = np.string_('1.1')
+        target.attrs['type'] = np.bytes_('Stimuli')
+        target.attrs['version'] = np.bytes_('1.1')
 
         for n, stimulus in enumerate(tqdm(self.stimuli, disable=not verbose)):
             target.create_dataset(str(n), data=stimulus, compression=compression, compression_opts=compression_opts)
@@ -209,7 +209,7 @@ class Stimuli(Sequence):
     def _attributes_to_hdf5(self, target):
         for attribute_name, attribute_value in self.attributes.items():
             create_hdf5_dataset(target, attribute_name, attribute_value)
-        target.attrs['__attributes__'] = np.string_(json.dumps(self.__attributes__))
+        target.attrs['__attributes__'] = np.bytes_(json.dumps(self.__attributes__))
 
     @classmethod
     def _get_attributes_from_hdf5(cls, source, data_version, data_version_for_attribute_list):
@@ -352,8 +352,8 @@ class FileStimuli(Stimuli):
         """ Write FileStimuli to hdf5 file or hdf5 group
         """
 
-        target.attrs['type'] = np.string_('FileStimuli')
-        target.attrs['version'] = np.string_('2.1')
+        target.attrs['type'] = np.bytes_('FileStimuli')
+        target.attrs['version'] = np.bytes_('2.1')
 
         import h5py
         # make sure everything is unicode

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -117,8 +117,10 @@ def test_create_subset_scanpath_fixations(file_stimuli_with_attributes, scanpath
     sub_stimuli, sub_fixations = pysaliency.datasets.create_subset(file_stimuli_with_attributes, scanpath_fixations, stimulus_indices)
 
     expected_sub_fixations = scanpath_fixations.filter_scanpaths(scanpath_indices).copy()
-    expected_sub_fixations.scanpaths.n = sub_fixations.scanpaths.n
-    expected_sub_fixations.n = sub_fixations.n
+    expected_scanpath_n = np.array([stimulus_indices.index(n) for n in expected_sub_fixations.scanpaths.n])
+    expected_sub_fixations.scanpaths.n = expected_scanpath_n
+    expected_fixation_n = np.array([stimulus_indices.index(n) for n in expected_sub_fixations.n])
+    expected_sub_fixations.n = expected_fixation_n
 
     assert_scanpath_fixations_equal(sub_fixations, expected_sub_fixations)
 
@@ -132,8 +134,10 @@ def test_create_subset_fixation_trains(file_stimuli_with_attributes, fixation_tr
     sub_stimuli, sub_fixations = pysaliency.datasets.create_subset(file_stimuli_with_attributes, fixation_trains, stimulus_indices)
 
     expected_sub_fixations= fixation_trains.filter_scanpaths(scanpath_indices).copy()
-    expected_sub_fixations.scanpaths.n = sub_fixations.scanpaths.n
-    expected_sub_fixations.n = sub_fixations.n
+    expected_scanpath_n = np.array([stimulus_indices.index(n) for n in expected_sub_fixations.scanpaths.n])
+    expected_sub_fixations.scanpaths.n = expected_scanpath_n
+    expected_fixation_n = np.array([stimulus_indices.index(n) for n in expected_sub_fixations.n])
+    expected_sub_fixations.n = expected_fixation_n
 
     assert_fixation_trains_equal(sub_fixations, expected_sub_fixations)
 
@@ -148,8 +152,8 @@ def test_create_subset_fixations(file_stimuli_with_attributes, fixation_trains, 
     sub_stimuli, sub_fixations = pysaliency.datasets.create_subset(file_stimuli_with_attributes, fixations, stimulus_indices)
 
     expected_sub_fixations= fixations[fixation_indices].copy()
-    expected_sub_fixations.n = sub_fixations.n
-
+    expected_fixation_n = np.array([stimulus_indices.index(n) for n in expected_sub_fixations.n])
+    expected_sub_fixations.n = expected_fixation_n
     assert not isinstance(sub_fixations, pysaliency.FixationTrains)
     assert_fixations_equal(sub_fixations, expected_sub_fixations)
 

--- a/tests/datasets/utils.py
+++ b/tests/datasets/utils.py
@@ -60,6 +60,7 @@ def assert_fixations_equal(f1, f2, crop_length=False):
     np.testing.assert_array_equal(f1.x, f2.x)
     np.testing.assert_array_equal(f1.y, f2.y)
     np.testing.assert_array_equal(f1.t, f2.t)
+    np.testing.assert_array_equal(f1.n, f2.n)
     assert_variable_length_array_equal(f1.x_hist, f2.x_hist)
     assert_variable_length_array_equal(f1.y_hist, f2.y_hist)
     assert_variable_length_array_equal(f1.t_hist, f2.t_hist)


### PR DESCRIPTION
only happened for ScanpathFixations. Fixations and FixationTrains were correct. For ScanpathFixations, the `n` attributes of scanpaths and fixations were not updated to reflect the new indices.