### PR TITLE
bugfix: MIT1003 doesn't work with octave

### DIFF
--- a/tests/test_external_datasets.py
+++ b/tests/test_external_datasets.py
@@ -201,7 +201,6 @@ def test_cat2000_test(location):
 
 @pytest.mark.slow
 @pytest.mark.download
-@pytest.mark.skip_octave
 @pytest.mark.matlab
 def test_mit1003(location, matlab):
     real_location = _location(location)
@@ -252,16 +251,12 @@ def test_mit1003(location, matlab):
     for i in range(len(fixations.x)):
         assert len(remove_trailing_nans(fixations.duration_hist[i])) == len(remove_trailing_nans(fixations.x_hist[i]))
 
-    assert 'durations' in fixations.scanpath_fixation_attributes
-    assert len(fixations.scanpath_fixation_attributes['durations']) == len(fixations.train_xs)
-    for i in range(len(fixations.train_xs)):
-        assert len(remove_trailing_nans(fixations.scanpath_fixation_attributes['durations'][i])) == len(remove_trailing_nans(fixations.train_xs[i]))
+    assert 'durations' in fixations.scanpaths.fixation_attributes
 
     assert len(fixations) == len(pysaliency.datasets.remove_out_of_stimulus_fixations(stimuli, fixations))
 
 @pytest.mark.slow
 @pytest.mark.download
-@pytest.mark.skip_octave
 @pytest.mark.matlab
 def test_mit1003_onesize(location, matlab):
     real_location = _location(location)


### PR DESCRIPTION
This commit patches the matlab extraction code for MIT1003 to work with newer octave versions which do not include `nanmedian` and `nanvar` anymore. Instead `median` and `var` are used with the `'omitnan"` flag.