### PR TITLE
Fix saliency map conversation tests

### DIFF
--- a/pysaliency/optpy/__init__.py
+++ b/pysaliency/optpy/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 
-from .optimization import ParameterManager, minimize
+from .optimization import ParameterManager, minimize, LinearConstraint
 from .jacobian import FunctionWithApproxJacobian, FunctionWithApproxJacobianCentral

--- a/pysaliency/optpy/optimization.py
+++ b/pysaliency/optpy/optimization.py
@@ -13,6 +13,15 @@ import scipy.optimize
 from .jacobian import FunctionWithApproxJacobian
 
 
+class LinearConstraint(object):
+    """Allows to build a linear constraint over the parameters by specifying one matrix for each parameter which will be concatenated as needed"""
+    def __init__(self, A_dict, lb=-np.inf, ub=np.inf, keep_feasible=False):
+        self.A_dict = A_dict
+        self.lb = lb
+        self.ub = ub
+        self.keep_feasible = keep_feasible
+
+
 # TODO: Remove, once https://github.com/scipy/scipy/pull/11872 is merged and published
 class MemoizeJac(object):
     """ Decorator that caches the value and gradient of function each time it
@@ -93,6 +102,8 @@ class ParameterManager(object):
             shape = self.param_values[param_name].shape
             if len(shape) > 1:
                 raise ValueError('Arrays with more than one dimension are not yet supported!')
+            if len(shape) == 0:
+                return 1
             return shape[0]
 
 
@@ -127,6 +138,47 @@ def wrap_parameter_manager(f, parameter_manager, additional_kwargs=None):
                 kwargs.update(additional_kwargs)
             return f(*params, **kwargs)
         return new_f
+
+
+
+def wrap_linear_constraint(constraint: LinearConstraint, parameter_manager: 'ParameterManager') -> scipy.optimize.LinearConstraint:
+    """Wraps a LinearConstraint object into a scipy.optimize.LinearConstraint object"""
+    # TODO: hande case that all relevant parameters are not being optimized
+
+    # get output dimension
+    output_dims = []
+    for A in constraint.A_dict.values():
+        if A is not None:
+            output_dims.append(A.shape[0])
+
+    if len(set(output_dims)) > 1:
+        raise ValueError(f'All A matrices must have the same number of rows! Got {output_dims}')
+
+    output_dim = output_dims[0]
+
+    A_dict = dict(constraint.A_dict)
+
+    lb = constraint.lb
+    ub = constraint.ub
+    for param_name in parameter_manager.parameters:
+        A = constraint.A_dict.get(param_name, None)
+        if param_name in parameter_manager.optimize:
+            if A is None:
+                length = parameter_manager.get_length(param_name)
+                A = np.zeros((output_dim, length))
+                A_dict[param_name] = A
+        else:
+            if A is not None:
+                param_value = np.atleast_1d(parameter_manager.param_values[param_name])
+                constraint_value = np.dot(A, param_value)
+                if np.isfinite(lb):
+                    lb = lb - constraint_value
+                if np.isfinite(ub):
+                    ub = ub - constraint_value
+
+    A_list = [A_dict[param_name] for param_name in parameter_manager.optimize]
+    A = np.concatenate(A_list, axis=1)
+    return scipy.optimize.LinearConstraint(A=A, lb=lb, ub=ub, keep_feasible=constraint.keep_feasible)
 
 
 def minimize(f, parameter_manager_or_x0, optimize=None, args=(), kwargs=None, method='BFGS',
@@ -188,9 +240,14 @@ def minimize(f, parameter_manager_or_x0, optimize=None, args=(), kwargs=None, me
         constraints = [constraints]
     new_constraints = []
     for constraint in constraints:
-        new_constraint = constraint.copy()
-        new_constraint['fun'] = wrap_parameter_manager(constraint['fun'], parameter_manager)
-        new_constraints.append(new_constraint)
+        if isinstance(constraint, dict):
+            new_constraint = constraint.copy()
+            new_constraint['fun'] = wrap_parameter_manager(constraint['fun'], parameter_manager)
+            new_constraints.append(new_constraint)
+        elif isinstance(constraint, LinearConstraint):
+            new_constraints.append(wrap_linear_constraint(constraint, parameter_manager))
+        else:
+            raise NotImplementedError('Only dictionaries and LinearConstraints are supported as constraints')
 
     #Adapt bounds:
     if bounds is not None:

--- a/pysaliency/optpy/optimization.py
+++ b/pysaliency/optpy/optimization.py
@@ -22,33 +22,6 @@ class LinearConstraint(object):
         self.keep_feasible = keep_feasible
 
 
-# TODO: Remove, once https://github.com/scipy/scipy/pull/11872 is merged and published
-class MemoizeJac(object):
-    """ Decorator that caches the value and gradient of function each time it
-    is called. """
-
-    def __init__(self, fun):
-        self.fun = fun
-        self.jac = None
-        self.value = None
-        self.x = None
-
-    def compute_if_needed(self, x, *args):
-        if self.value is None or self.jac is None or not np.all(x == self.x):
-            self.x = np.asarray(x).copy()
-            fg = self.fun(x, *args)
-            self.jac = fg[1]
-            self.value = fg[0]
-
-    def __call__(self, x, *args):
-        self.compute_if_needed(x, *args)
-        return self.value
-
-    def derivative(self, x, *args):
-        self.compute_if_needed(x, *args)
-        return self.jac
-
-
 class ParameterManager(object):
     def __init__(self, parameters, optimize, **kwargs):
         """ Create a parameter manager
@@ -229,11 +202,6 @@ def minimize(f, parameter_manager_or_x0, optimize=None, args=(), kwargs=None, me
         fun = jac_approx(wrapped_f, 1e-8)
         jac_ = fun.jac
         fun_ = fun.func
-
-    # TODO: Remove once https://github.com/scipy/scipy/pull/11872 is merged
-    if jac_ is True:
-        fun_ = MemoizeJac(fun_)
-        jac_ = fun_.derivative
 
     # Adapt constraints
     if isinstance(constraints, dict):

--- a/pysaliency/saliency_map_conversion_theano.py
+++ b/pysaliency/saliency_map_conversion_theano.py
@@ -215,6 +215,7 @@ def optimize_saliency_map_conversion(saliency_map_processing, saliency_maps, x_i
 
     centerbias_value = smp.centerbias_ys.get_value()
 
+    # TODO: move to LinearConstraints in the torch implementation
     if isinstance(saliency_map_processing, SaliencyMapProcessing):
         print("Using density constraints")
         bounds = {'nonlinearity': [(nonlinearity_min, 1e7) for i in range(num_nonlinearity)],

--- a/tests/test_saliency_map_conversion_torch_extended.py
+++ b/tests/test_saliency_map_conversion_torch_extended.py
@@ -138,7 +138,7 @@ def test_optimize_for_information_gain(stimuli, fixations, saliency_model, proba
         verbose=2,
         batch_size=10,
         minimize_options={'verbose': 10},
-        maxiter=500,
+        maxiter=100,
         num_nonlinearity=num_nonlinearity,
         num_centerbias=num_centerbias,
         blur_radius=blur_radius,


### PR DESCRIPTION
Since scipy 1.15.0, many saliency map conversation tests failed. It turned out this was because a bug was fixed that in my case (many linear constraints) actually helped. Now we use proper linear constraints where possible, resulting in faster optimization and passing tests.