### PR TITLE
Chore: remove dependency on dill

### DIFF
--- a/pysaliency/external_datasets/utils.py
+++ b/pysaliency/external_datasets/utils.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 import os
 import shutil
-
-import dill
+import warnings
 
 from ..datasets import FileStimuli, Stimuli, read_hdf5
 
@@ -61,4 +60,10 @@ def _load(filename):
     stem, ext = os.path.splitext(filename)
     pydat_filename = stem + '.pydat'
 
-    return dill.load(open(pydat_filename, 'rb'))
+    if os.path.isfile(pydat_filename):
+        import dill
+        # raise deprecation warning
+        warnings.warn("Using pickle files is deprecated. Please convert to hdf5 files instead. Pickle support will be removed in pysaliency 0.4", DeprecationWarning, stacklevel=2)
+        return dill.load(open(pydat_filename, 'rb'))
+    else:
+        raise FileNotFoundError(f"Neither {filename} nor {pydat_filename} exist.")

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     install_requires=[
         'boltons',
         'deprecation',
-        'dill',
         'imageio',
         'natsort',
         'numba',


### PR DESCRIPTION
Early in pysaliency, we used dill to save datasets and fixations to pickle files. Since then, hdf5 turned out to be more useful for this and I want to get rid of the dill feature. For now it's only deprecated and dill is not required anymore to run pysaliency unless you want to load pickle files. But the feature is still tested. In a later version, we can get rid of it for good.

Closes #101.