### PR TITLE
Bugfix: Loading string attributes from HDF5

### DIFF
--- a/pysaliency/datasets/utils.py
+++ b/pysaliency/datasets/utils.py
@@ -61,6 +61,18 @@ def create_hdf5_dataset(target, name, data):
     else:
         target.create_dataset(name, data=data)
 
+def load_hdf5_dataset(source, name):
+    import h5py
+
+    if name not in source:
+        raise KeyError(f"Dataset '{name}' not found in HDF5 file.")
+
+    dataset = source[name]
+    if isinstance(dataset, h5py.Dataset) and dataset.dtype == h5py.special_dtype(vlen=str):
+        return [decode_string(item) for item in dataset[...]]
+    else:
+        return dataset[...]
+
 
 def get_merged_attribute_list(attributes):
     all_attributes = set(attributes[0])
@@ -82,7 +94,7 @@ def _load_attribute_dict_from_hdf5(attribute_group):
         json_attributes = json_attributes.decode('utf8')
     __attributes__ = json.loads(json_attributes)
 
-    attributes = {attribute: attribute_group[attribute][...] for attribute in __attributes__}
+    attributes = {attribute: load_hdf5_dataset(attribute_group, attribute) for attribute in __attributes__}
     return attributes
 
 

--- a/tests/datasets/test_fixations.py
+++ b/tests/datasets/test_fixations.py
@@ -55,6 +55,7 @@ class TestFixations(TestWithData):
         ns = [0, 0, 1]
         subject = [0, 1, 1]
         tasks = [0, 1, 0]
+        string_attribute = ['train', 'train', 'test']
         some_attribute = np.arange(len(sum(xs_trains, [])))
         # Create Fixations
         f = pysaliency.FixationTrains.from_fixation_trains(
@@ -64,7 +65,7 @@ class TestFixations(TestWithData):
             ns,
             subject,
             attributes={'some_attribute': some_attribute},
-            scanpath_attributes={'task': tasks},
+            scanpath_attributes={'task': tasks, 'string_attribute': string_attribute},
         )
 
         # Test fixation trains
@@ -179,6 +180,7 @@ def scanpath_fixations() -> ScanpathFixations:
     ns = [0, 0, 1]
     subject = [0, 1, 1]
     tasks = [0, 1, 0]
+    string_attribute = ['train', 'train', 'test']
     multi_dim_attribute = [[0.0, 1],[2, 3], [4, 5.5]]
     durations_train = [
         [42, 25, 100],
@@ -193,6 +195,7 @@ def scanpath_fixations() -> ScanpathFixations:
             'task': tasks,
             'multi_dim_attribute': multi_dim_attribute,
             'subject': subject,
+            'string_attribute': string_attribute,
         },
         fixation_attributes={'durations': durations_train, 'ts': ts_trains},
         attribute_mapping={'durations': 'duration', 'ts': 't'},
@@ -517,7 +520,7 @@ def test_concatenate_scanpath_fixations(scanpath_fixations):
         np.concatenate((scanpath_fixations.n, scanpath_fixations.n))
     )
 
-    assert set(new_scanpath_fixations.__attributes__) == {'subject', 'duration', 'duration_hist', 'multi_dim_attribute', 'scanpath_index', 'task'}
+    assert set(new_scanpath_fixations.__attributes__) == {'subject', 'duration', 'duration_hist', 'multi_dim_attribute', 'scanpath_index', 'task', 'string_attribute'}
 
 
 def test_concatenate_scanpath_fixations_partial_attributes(scanpath_fixations):
@@ -540,7 +543,7 @@ def test_concatenate_scanpath_fixations_partial_attributes(scanpath_fixations):
         np.concatenate((scanpath_fixations.n, scanpath_fixations2.n))
     )
 
-    assert set(new_fixation_trains.__attributes__) == {'subject', 'duration', 'duration_hist', 'multi_dim_attribute', 'scanpath_index'}
+    assert set(new_fixation_trains.__attributes__) == {'subject', 'duration', 'duration_hist', 'multi_dim_attribute', 'scanpath_index', 'string_attribute'}
 
 
 def test_concatenate_fixation_trains_partial_attributes(fixation_trains):


### PR DESCRIPTION
String attributes are saved to HDF5 as bytes, but when loading them back, the unicode was not decoded, resulting in an attribute with bytes content. This is now fixed and a test has been added.