### PR TITLE
Fix SubjectDependentModel to use 'subject' instead of deprecated 'subjects'

### DIFF
--- a/pysaliency/models.py
+++ b/pysaliency/models.py
@@ -572,12 +572,12 @@ class SubjectDependentModel(DisjointUnionModel):
 
     def _split_fixations(self, stimuli, fixations):
         for s in self.subject_models:
-            yield fixations.subjects == s, self.subject_models[s]
+            yield fixations.subject == s, self.subject_models[s]
 
     def conditional_log_density(self, stimulus, x_hist, y_hist, t_hist, attributes=None, out=None, **kwargs):
-        if 'subjects' not in attributes:
+        if 'subject' not in attributes:
             raise ValueError("SubjectDependentModel can't compute conditional log densities without subject indication!")
-        return self.subject_models[attributes['subjects']].conditional_log_density(
+        return self.subject_models[attributes['subject']].conditional_log_density(
             stimulus, x_hist, y_hist, t_hist, attributes=attributes, **kwargs)
 
     def get_saliency_map_model_for_sAUC(self, baseline_model):


### PR DESCRIPTION
The fixations attribute was renamed from 'subjects' to 'subject' for consistency. This fixes SubjectDependentModel to use the new attribute name in both _split_fixations and conditional_log_density.