### PR TITLE
ENH: faster building of ScanpathFixations

### DIFF
--- a/pysaliency/datasets/fixations.py
+++ b/pysaliency/datasets/fixations.py
@@ -392,38 +392,55 @@ class ScanpathFixations(Fixations):
         max_scanpath_length = scanpaths.length.max() if len(scanpaths) else 0
         max_history_length = max(max_scanpath_length - 1, 0)
 
-        # Create conditional fixations
-        x = np.empty(N_fixations)
-        y = np.empty(N_fixations)
-        t = np.empty(N_fixations)
+        if N_fixations == 0:
+            # Edge case: no fixations at all
+            x = np.empty(0)
+            y = np.empty(0)
+            t = np.empty(0)
+            n = np.empty(0, dtype=int)
+            scanpath_index = np.empty(0, dtype=int)
+            x_hist = VariableLengthArray(np.empty((0, 0)), np.empty(0, dtype=int))
+            y_hist = VariableLengthArray(np.empty((0, 0)), np.empty(0, dtype=int))
+            t_hist = VariableLengthArray(np.empty((0, 0)), np.empty(0, dtype=int))
+            hist_lengths = np.empty(0, dtype=int)
+            mask = np.empty((0, 0), dtype=bool)
+            row_src = np.empty(0, dtype=int)
+            col_src = np.empty(0, dtype=int)
+            scanpath_indices = np.empty(0, dtype=int)
+            fix_indices = np.empty(0, dtype=int)
+        else:
+            # Precompute index arrays
+            scanpath_indices = np.repeat(np.arange(len(scanpaths)), scanpaths.length)
+            fix_indices = np.concatenate([np.arange(length) for length in scanpaths.length])
 
-        x_hist = []
-        y_hist = []
-        t_hist = []
-        n = np.empty(N_fixations, dtype=int)
-        subject = np.empty(N_fixations, dtype=int)
-        scanpath_index = np.empty(N_fixations, dtype=int)
+            # Direct values via advanced indexing
+            x = scanpaths.xs._data[scanpath_indices, fix_indices]
+            y = scanpaths.ys._data[scanpath_indices, fix_indices]
+            t = scanpaths.ts._data[scanpath_indices, fix_indices]
+            n = scanpaths.n[scanpath_indices]
+            scanpath_index = scanpath_indices.copy()
 
-        out_index = 0
-        # TODO: maybe implement in numba?
-        # probably best: have function fill_fixation_data(scanpath_data, fixation_data, hist_data=None)
-        for train_index in range(len(scanpaths)):
-            for fix_index in range(scanpaths.length[train_index]):
-                x[out_index] = scanpaths.xs[train_index][fix_index]
-                y[out_index] = scanpaths.ys[train_index][fix_index]
-                t[out_index] = scanpaths.ts[train_index][fix_index]
-                n[out_index] = scanpaths.n[train_index]
-                # subject[out_index] = scanpaths.scanpath_attributes['subject'][train_index]
-                scanpath_index[out_index] = train_index
-                x_hist.append(scanpaths.xs[train_index][:fix_index])
-                y_hist.append(scanpaths.ys[train_index][:fix_index])
-                t_hist.append(scanpaths.ts[train_index][:fix_index])
-                out_index += 1
+            # History arrays
+            hist_lengths = fix_indices
+            col_indices = np.arange(max_history_length)
+            mask = col_indices[None, :] < hist_lengths[:, None]
 
-        x_hist = VariableLengthArray(x_hist)
-        y_hist = VariableLengthArray(y_hist)
-        t_hist = VariableLengthArray(t_hist)
+            row_src = np.broadcast_to(scanpath_indices[:, None], mask.shape)[mask]
+            col_src = np.broadcast_to(col_indices[None, :], mask.shape)[mask]
 
+            x_hist_data = np.full((N_fixations, max_history_length), np.nan)
+            x_hist_data[mask] = scanpaths.xs._data[row_src, col_src]
+            x_hist = VariableLengthArray(x_hist_data, hist_lengths)
+
+            y_hist_data = np.full((N_fixations, max_history_length), np.nan)
+            y_hist_data[mask] = scanpaths.ys._data[row_src, col_src]
+            y_hist = VariableLengthArray(y_hist_data, hist_lengths)
+
+            t_hist_data = np.full((N_fixations, max_history_length), np.nan)
+            t_hist_data[mask] = scanpaths.ts._data[row_src, col_src]
+            t_hist = VariableLengthArray(t_hist_data, hist_lengths)
+
+        # Scanpath attributes
         auto_attributes = []
         attributes = {
             'scanpath_index': scanpath_index,
@@ -433,40 +450,36 @@ class ScanpathFixations(Fixations):
             new_attribute_name = scanpaths.attribute_mapping.get(attribute_name, attribute_name)
             if new_attribute_name in attributes:
                 raise ValueError("attribute name clash: {new_attribute_name}".format(new_attribute_name=new_attribute_name))
-            attribute_shape = [] if not len(value) else np.asarray(value[0]).shape
-            attributes[new_attribute_name] = np.empty([N_fixations] + list(attribute_shape), dtype=value.dtype)
+            attributes[new_attribute_name] = np.repeat(value, scanpaths.length, axis=0)
             auto_attributes.append(new_attribute_name)
 
-            out_index = 0
-            for train_index in range(len(scanpaths)):
-                for _ in range(scanpaths.length[train_index]):
-                    attributes[new_attribute_name][out_index] = value[train_index]
-                    out_index += 1
-
-
+        # Fixation attributes + histories
         for attribute_name, value in scanpaths.fixation_attributes.items():
             if attribute_name == 'ts':
                 continue
             new_attribute_name = scanpaths.attribute_mapping.get(attribute_name, attribute_name)
             if new_attribute_name in attributes:
                 raise ValueError("attribute name clash: {new_attribute_name}".format(new_attribute_name=new_attribute_name))
-            attributes[new_attribute_name] = np.empty(N_fixations)
+
+            if N_fixations == 0:
+                attributes[new_attribute_name] = np.empty(0)
+            else:
+                attributes[new_attribute_name] = value._data[scanpath_indices, fix_indices]
             auto_attributes.append(new_attribute_name)
 
             hist_attribute_name = new_attribute_name + '_hist'
             if hist_attribute_name in attributes:
                 raise ValueError("attribute name clash: {hist_attribute_name}".format(hist_attribute_name=hist_attribute_name))
-            attributes[hist_attribute_name] = np.full((N_fixations, max_history_length), fill_value=np.nan)
+
+            if N_fixations == 0:
+                attributes[hist_attribute_name] = VariableLengthArray(np.empty((0, 0)), np.empty(0, dtype=int))
+            else:
+                hist_data = np.full((N_fixations, max_history_length), fill_value=np.nan)
+                hist_data[mask] = value._data[row_src, col_src]
+                attributes[hist_attribute_name] = VariableLengthArray(hist_data, hist_lengths)
             auto_attributes.append(hist_attribute_name)
 
-            out_index = 0
-            for train_index in range(len(scanpaths)):
-                for fix_index in range(scanpaths.length[train_index]):
-                    attributes[new_attribute_name][out_index] = value[train_index, fix_index]
-                    attributes[hist_attribute_name][out_index][:fix_index] = value[train_index, :fix_index]
-                    out_index += 1
-
-            attributes[hist_attribute_name] = VariableLengthArray(attributes[hist_attribute_name], x_hist.lengths)
+        subject = np.empty(N_fixations, dtype=int)
 
         super().__init__(
             x=x,

--- a/tests/datasets/test_fixations.py
+++ b/tests/datasets/test_fixations.py
@@ -370,6 +370,75 @@ def test_scanpath_fixations_scanpath_fixation_attributes(scanpath_fixations):
     np.testing.assert_array_equal(scanpath_fixations.duration_hist[7], [200, 150])
 
 
+def test_scanpath_fixations_values(scanpath_fixations):
+    """Regression test: exact values produced by ScanpathFixations.__init__"""
+    # x, y, t from the 3 scanpaths: [0,1,2], [2,2], [1,5,3]
+    np.testing.assert_array_equal(scanpath_fixations.x, [0, 1, 2, 2, 2, 1, 5, 3])
+    np.testing.assert_array_equal(scanpath_fixations.y, [10, 11, 12, 12, 12, 21, 25, 33])
+    np.testing.assert_array_equal(scanpath_fixations.t, [0, 200, 600, 100, 400, 50, 500, 900])
+    np.testing.assert_array_equal(scanpath_fixations.n, [0, 0, 0, 0, 0, 1, 1, 1])
+    np.testing.assert_array_equal(scanpath_fixations.scanpath_index, [0, 0, 0, 1, 1, 2, 2, 2])
+
+    # x_hist
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[0], [])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[1], [0])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[2], [0, 1])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[3], [])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[4], [2])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[5], [])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[6], [1])
+    np.testing.assert_array_equal(scanpath_fixations.x_hist[7], [1, 5])
+
+    # y_hist
+    np.testing.assert_array_equal(scanpath_fixations.y_hist[0], [])
+    np.testing.assert_array_equal(scanpath_fixations.y_hist[1], [10])
+    np.testing.assert_array_equal(scanpath_fixations.y_hist[2], [10, 11])
+    np.testing.assert_array_equal(scanpath_fixations.y_hist[5], [])
+    np.testing.assert_array_equal(scanpath_fixations.y_hist[7], [21, 25])
+
+    # t_hist
+    np.testing.assert_array_equal(scanpath_fixations.t_hist[0], [])
+    np.testing.assert_array_equal(scanpath_fixations.t_hist[2], [0, 200])
+    np.testing.assert_array_equal(scanpath_fixations.t_hist[7], [50, 500])
+
+    # scanpath_history_length
+    np.testing.assert_array_equal(scanpath_fixations.scanpath_history_length, [0, 1, 2, 0, 1, 0, 1, 2])
+
+    # task (scanpath attribute)
+    np.testing.assert_array_equal(scanpath_fixations.task, [0, 0, 0, 1, 1, 0, 0, 0])
+
+    # multi_dim_attribute (scanpath attribute with shape)
+    np.testing.assert_array_equal(scanpath_fixations.multi_dim_attribute[0], [0, 1])
+    np.testing.assert_array_equal(scanpath_fixations.multi_dim_attribute[3], [2, 3])
+    np.testing.assert_array_equal(scanpath_fixations.multi_dim_attribute[5], [4, 5.5])
+
+    # duration (fixation attribute) and duration_hist
+    np.testing.assert_array_equal(scanpath_fixations.duration, [42, 25, 100, 99, 98, 200, 150, 120])
+    np.testing.assert_array_equal(scanpath_fixations.duration_hist[0], [])
+    np.testing.assert_array_equal(scanpath_fixations.duration_hist[1], [42])
+    np.testing.assert_array_equal(scanpath_fixations.duration_hist[2], [42, 25])
+    np.testing.assert_array_equal(scanpath_fixations.duration_hist[4], [99])
+    np.testing.assert_array_equal(scanpath_fixations.duration_hist[7], [200, 150])
+
+
+def test_scanpath_fixations_empty():
+    """ScanpathFixations should handle empty Scanpaths without errors."""
+    scanpaths = Scanpaths(
+        xs=[],
+        ys=[],
+        n=[],
+        length=[],
+        scanpath_attributes={},
+        fixation_attributes={},
+    )
+    sf = ScanpathFixations(scanpaths=scanpaths)
+    assert len(sf.x) == 0
+    assert len(sf.y) == 0
+    assert len(sf.t) == 0
+    assert len(sf.n) == 0
+    assert len(sf.x_hist) == 0
+
+
 def test_fixation_trains_scanpath_fixation_attributes(fixation_trains):
     # test attribute itself
     assert "durations" in fixation_trains.scanpath_fixation_attributes


### PR DESCRIPTION
The constructor of ScanpathFixations was very slow because it handled every fixation individually. Now we use advanced indexing to speed it up, which should make loading larger datasets like CAT2000 substantially faster.