### PR TITLE
ENH: HDF5 save/reload for baseline models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   * Feature: `pysaliency.read_hdf5` now takes additional keyword arguments which are passed to the respective class methods. This allows, e.g., to load `FileStimuli` with caching disabled.
   * Enhancement: `pysaliency.HDF5Model` and `pysaliency.HDF5SaliencyMapModel` now better handle the case of loading a model for a subset of entries in the HDF5 file which might be saved under a certain common prefix.
   * Feature: `pysaliency.saliency_map_conversation_torch` now specifies constraints, where applicable, as linear. To that end, `pysaliency.optpy` now allows specifying linear constraints. This results in better optimization performance, especially since scipy 1.15.0 fixed a bug that in our case actually helped.
+  * Feature: `pysaliency.baseline_utils.BaselineModel` now supports `to_hdf5` / `read_hdf5` model persistence using HDF5 type `pysaliency.baseline_utils.BaselineModel`.
+  * Enhancement: Introduced unified HDF5 I/O dispatch in `pysaliency.hdf5` (`read_hdf5`) and routed `pysaliency.datasets.read_hdf5` through the dataset dispatcher for compatibility.
+  * Enhancement: `BaselineModel` no longer stores `stimuli` and `fixations` after initialization; it keeps only the normalized fixation representation used for predictions.
 
 
 * 0.2.22:

--- a/docs/superpowers/plans/2026-03-21-crossvalidated-baseline-model-hdf5.md
+++ b/docs/superpowers/plans/2026-03-21-crossvalidated-baseline-model-hdf5.md
@@ -1,0 +1,471 @@
+# CrossvalidatedBaselineModel HDF5 Save/Reload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `to_hdf5`/`read_hdf5` to `CrossvalidatedBaselineModel` so it can be serialized by parameters (not predictions), wired into the `pysaliency.read_hdf5` dispatcher.
+
+**Architecture:** Refactor `CrossvalidatedBaselineModel` to store only `fixations_n` (not the full fixations object), then add `to_hdf5`/`read_hdf5` following the exact same pattern as the already-complete `BaselineModel`. Register in the `_MODEL_READERS` dispatch table in `pysaliency/hdf5.py`.
+
+**Tech Stack:** Python, h5py, numpy, pytest. Build Cython extensions with `make cython` before running tests.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `pysaliency/baseline_utils.py` | Refactor `CrossvalidatedBaselineModel.__init__` and `_log_density`; add `to_hdf5` and `read_hdf5` |
+| `pysaliency/hdf5.py` | Add `_read_crossvalidated_baseline_model` helper; extend existing `_MODEL_READERS` dict |
+| `tests/test_baseline_utils.py` | Extend top-level import; add 6 new tests |
+| `tests/test_hdf5_io.py` | Extend top-level import; add 3 new tests for dispatcher, kwarg override, and cache bypass |
+
+---
+
+## Task 1: Refactor `CrossvalidatedBaselineModel` internals
+
+Replace `self.fixations` + `self.shape_cache` with `self.fixations_n`. Public constructor signature is unchanged.
+
+**Files:**
+- Modify: `pysaliency/baseline_utils.py:559-591`
+- Modify: `tests/test_baseline_utils.py`
+
+- [ ] **Step 1: Update the top-level import in `tests/test_baseline_utils.py`**
+
+The existing import block (lines 9–17) imports from `pysaliency.baseline_utils`. Add `CrossvalidatedBaselineModel` to it:
+
+```python
+from pysaliency.baseline_utils import (
+    BaselineModel,
+    CrossvalidatedBaselineModel,
+    CrossvalMultipleRegularizations,
+    GeneralMixtureKernelDensityEstimator,
+    KDEGoldModel,
+    MixtureKernelDensityEstimator,
+    ScikitLearnImageCrossValidationGenerator,
+    fill_fixation_map,
+)
+```
+
+- [ ] **Step 2: Write a failing test that asserts the new internal state**
+
+Add to `tests/test_baseline_utils.py`:
+
+```python
+def test_crossvalidated_baseline_model_stores_fixations_n(stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    assert hasattr(model, 'fixations_n')
+    assert not hasattr(model, 'fixations')
+    assert not hasattr(model, 'shape_cache')
+    np.testing.assert_array_equal(model.fixations_n, scanpath_fixations.n)
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+```bash
+python -m pytest --nomatlab tests/test_baseline_utils.py::test_crossvalidated_baseline_model_stores_fixations_n -v
+```
+
+Expected: FAIL — `model` has no `fixations_n`, still has `fixations` and `shape_cache`.
+
+- [ ] **Step 4: Implement the refactor**
+
+In `pysaliency/baseline_utils.py`, replace the `CrossvalidatedBaselineModel` class body (lines 559–591) with:
+
+```python
+class CrossvalidatedBaselineModel(Model):
+    def __init__(self, stimuli, fixations, bandwidth, eps=1e-20, **kwargs):
+        super(CrossvalidatedBaselineModel, self).__init__(**kwargs)
+        self.stimuli = stimuli
+        self.bandwidth = bandwidth
+        self.eps = eps
+        self.xs, self.ys = normalize_fixations(stimuli, fixations)
+        self.fixations_n = fixations.n.copy()
+
+    def _log_density(self, stimulus):
+        shape = stimulus.shape[0], stimulus.shape[1]
+
+        stimulus_id = get_image_hash(stimulus)
+        stimulus_index = self.stimuli.stimulus_ids.index(stimulus_id)
+
+        inds = self.fixations_n != stimulus_index
+
+        ZZ = np.zeros(shape)
+
+        _fixations = np.array([self.ys[inds]*shape[0], self.xs[inds]*shape[1]]).T
+        fill_fixation_map(ZZ, _fixations)
+        ZZ = gaussian_filter(ZZ, [self.bandwidth*shape[0], self.bandwidth*shape[1]])
+        ZZ *= (1-self.eps)
+        ZZ += self.eps * 1.0/(shape[0]*shape[1])
+        ZZ = np.log(ZZ)
+
+        ZZ -= logsumexp(ZZ)
+
+        return ZZ
+```
+
+- [ ] **Step 5: Run the new test plus the full baseline_utils suite**
+
+```bash
+python -m pytest --nomatlab tests/test_baseline_utils.py -v
+```
+
+Expected: all pass. If any existing test relied on `model.fixations` or `model.shape_cache`, it will fail here — fix it in the same commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pysaliency/baseline_utils.py tests/test_baseline_utils.py
+git commit -m "refactor: CrossvalidatedBaselineModel stores fixations_n, removes shape_cache"
+```
+
+---
+
+## Task 2: Add `to_hdf5` to `CrossvalidatedBaselineModel`
+
+**Files:**
+- Modify: `pysaliency/baseline_utils.py`
+- Modify: `tests/test_baseline_utils.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_baseline_utils.py`. Note: `import h5py` goes inside the test function body, matching the style of the existing `test_baseline_model_hdf5_type` test:
+
+```python
+def test_crossvalidated_baseline_model_hdf5_type(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_type.hdf5'
+    model.to_hdf5(path)
+
+    import h5py
+    with h5py.File(path, 'r') as f:
+        value = f.attrs['type']
+        if not isinstance(value, str):
+            value = value.decode('utf8')
+        assert value == 'pysaliency.baseline_utils.CrossvalidatedBaselineModel'
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+python -m pytest --nomatlab tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_type -v
+```
+
+Expected: FAIL — `CrossvalidatedBaselineModel` has no `to_hdf5`.
+
+- [ ] **Step 3: Implement `to_hdf5`**
+
+Add the method to `CrossvalidatedBaselineModel` in `pysaliency/baseline_utils.py`, immediately after `_log_density`. `hdf5_wrapper` is already imported from `.datasets.utils` at the top of the file:
+
+```python
+    @hdf5_wrapper(mode='w')
+    def to_hdf5(self, target, include_stimuli=True):
+        target.attrs['type'] = np.bytes_('pysaliency.baseline_utils.CrossvalidatedBaselineModel')
+        target.attrs['version'] = np.bytes_('1.0')
+        target.attrs['bandwidth'] = self.bandwidth
+        target.attrs['eps'] = self.eps
+        target.create_dataset('xs', data=self.xs)
+        target.create_dataset('ys', data=self.ys)
+        target.create_dataset('fixations_n', data=self.fixations_n)
+
+        if include_stimuli:
+            stimuli_group = target.create_group('stimuli')
+            self.stimuli.to_hdf5(stimuli_group)
+```
+
+- [ ] **Step 4: Run the type test**
+
+```bash
+python -m pytest --nomatlab tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_type -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pysaliency/baseline_utils.py tests/test_baseline_utils.py
+git commit -m "feat: add CrossvalidatedBaselineModel.to_hdf5"
+```
+
+---
+
+## Task 3: Add `read_hdf5` to `CrossvalidatedBaselineModel` with full roundtrip tests
+
+**Files:**
+- Modify: `pysaliency/baseline_utils.py`
+- Modify: `tests/test_baseline_utils.py`
+
+- [ ] **Step 1: Write all four failing tests at once**
+
+Add to `tests/test_baseline_utils.py`:
+
+```python
+def test_crossvalidated_baseline_model_hdf5_roundtrip_with_stimuli(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    first_prediction = model.log_density(stimuli[0]).copy()
+
+    path = tmp_path / 'cv_baseline.hdf5'
+    model.to_hdf5(path)
+
+    reloaded = CrossvalidatedBaselineModel.read_hdf5(path)
+    np.testing.assert_allclose(reloaded.log_density(stimuli[0]), first_prediction)
+
+
+def test_crossvalidated_baseline_model_hdf5_roundtrip_without_stimuli(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    first_prediction = model.log_density(stimuli[1]).copy()
+
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    reloaded = CrossvalidatedBaselineModel.read_hdf5(path, stimuli=stimuli)
+    np.testing.assert_allclose(reloaded.log_density(stimuli[1]), first_prediction)
+
+
+def test_crossvalidated_baseline_model_hdf5_error_without_stimuli(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    with pytest.raises(ValueError, match='stimuli'):
+        CrossvalidatedBaselineModel.read_hdf5(path)
+
+
+def test_crossvalidated_baseline_model_hdf5_stimuli_kwarg_overrides_embedded(tmp_path, stimuli, scanpath_fixations):
+    """stimuli= kwarg takes precedence over the embedded stimuli group."""
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    first_prediction = model.log_density(stimuli[0]).copy()
+
+    path = tmp_path / 'cv_baseline_with_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=True)
+
+    # Pass the same stimuli explicitly — should still work (kwarg wins)
+    reloaded = CrossvalidatedBaselineModel.read_hdf5(path, stimuli=stimuli)
+    assert reloaded.stimuli is stimuli
+    np.testing.assert_allclose(reloaded.log_density(stimuli[0]), first_prediction)
+```
+
+- [ ] **Step 2: Run to confirm all four fail**
+
+```bash
+python -m pytest --nomatlab \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_roundtrip_with_stimuli \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_roundtrip_without_stimuli \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_error_without_stimuli \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_stimuli_kwarg_overrides_embedded \
+  -v
+```
+
+Expected: all FAIL — `CrossvalidatedBaselineModel` has no `read_hdf5`.
+
+- [ ] **Step 3: Implement `read_hdf5`**
+
+Add to `CrossvalidatedBaselineModel` in `pysaliency/baseline_utils.py`. Decorator stack: `@classmethod` outermost, `@hdf5_wrapper(mode='r')` inner — this matches `BaselineModel.read_hdf5` exactly. `Model` is already available at module level via `from . import Model`.
+
+```python
+    @classmethod
+    @hdf5_wrapper(mode='r')
+    def read_hdf5(
+        cls,
+        source,
+        *,
+        stimuli=None,
+        caching=True,
+        memory_cache_size=None,
+        cache_location=None,
+    ):
+        from .hdf5 import read_hdf5 as _read_hdf5
+
+        data_type = decode_string(source.attrs['type'])
+        data_version = decode_string(source.attrs['version'])
+
+        if data_type != 'pysaliency.baseline_utils.CrossvalidatedBaselineModel':
+            raise ValueError("Invalid type! Expected 'pysaliency.baseline_utils.CrossvalidatedBaselineModel', got", data_type)
+        if data_version != '1.0':
+            raise ValueError("Invalid version! Expected '1.0', got", data_version)
+
+        if stimuli is None:
+            if 'stimuli' not in source:
+                raise ValueError(
+                    "No stimuli found in HDF5 file. Pass stimuli= explicitly."
+                )
+            stimuli = _read_hdf5(source['stimuli'])
+
+        model = cls.__new__(cls)
+        Model.__init__(model, cache_location=cache_location, caching=caching, memory_cache_size=memory_cache_size)
+        model.bandwidth = source.attrs['bandwidth']
+        model.eps = source.attrs['eps']
+        model.xs = source['xs'][...]
+        model.ys = source['ys'][...]
+        model.fixations_n = source['fixations_n'][...]
+        model.stimuli = stimuli
+
+        return model
+```
+
+- [ ] **Step 4: Run all five tests (type + 4 roundtrip/override)**
+
+```bash
+python -m pytest --nomatlab \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_type \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_roundtrip_with_stimuli \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_roundtrip_without_stimuli \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_error_without_stimuli \
+  tests/test_baseline_utils.py::test_crossvalidated_baseline_model_hdf5_stimuli_kwarg_overrides_embedded \
+  -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run the full test suite to catch regressions**
+
+```bash
+python -m pytest --nomatlab tests/test_baseline_utils.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pysaliency/baseline_utils.py tests/test_baseline_utils.py
+git commit -m "feat: add CrossvalidatedBaselineModel.read_hdf5 with optional stimuli embedding"
+```
+
+---
+
+## Task 4: Register in `pysaliency.read_hdf5` dispatcher and add integration tests
+
+**Files:**
+- Modify: `pysaliency/hdf5.py`
+- Modify: `tests/test_hdf5_io.py`
+
+- [ ] **Step 1: Update the import in `tests/test_hdf5_io.py`**
+
+The existing file imports `BaselineModel` from `pysaliency.baseline_utils`. Extend it to also import `CrossvalidatedBaselineModel`:
+
+```python
+from pysaliency.baseline_utils import BaselineModel, CrossvalidatedBaselineModel
+```
+
+- [ ] **Step 2: Write the three failing dispatcher tests**
+
+Add to `tests/test_hdf5_io.py`:
+
+```python
+def test_unified_read_hdf5_reads_crossvalidated_baseline_model(tmp_path):
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = CrossvalidatedBaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_model.hdf5'
+    model.to_hdf5(path)
+
+    loaded = pysaliency.read_hdf5(path)
+    assert isinstance(loaded, CrossvalidatedBaselineModel)
+    np.testing.assert_allclose(loaded.log_density(stimuli[0]), model.log_density(stimuli[0]))
+
+
+def test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg(tmp_path):
+    """stimuli= kwarg is forwarded correctly through the dispatcher."""
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = CrossvalidatedBaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    loaded = pysaliency.read_hdf5(str(path), stimuli=stimuli)
+    assert isinstance(loaded, CrossvalidatedBaselineModel)
+    assert loaded.stimuli is stimuli
+    np.testing.assert_allclose(loaded.log_density(stimuli[0]), model.log_density(stimuli[0]))
+
+
+def test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg_bypasses_cache(tmp_path):
+    """Regression: stimuli= kwarg must bypass WeakValueDictionary cache in _read_hdf5_from_file."""
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = CrossvalidatedBaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    loaded = pysaliency.read_hdf5(str(path), stimuli=stimuli)
+    assert loaded.stimuli is stimuli
+
+    # Second call with a different stimuli object — must not return the cached first result
+    stimuli2 = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    loaded2 = pysaliency.read_hdf5(str(path), stimuli=stimuli2)
+    assert loaded2.stimuli is stimuli2
+    np.testing.assert_allclose(loaded2.log_density(stimuli2[0]), CrossvalidatedBaselineModel(stimuli2, fixations, bandwidth=0.1).log_density(stimuli2[0]))
+```
+
+- [ ] **Step 3: Run to confirm all three fail**
+
+```bash
+python -m pytest --nomatlab \
+  tests/test_hdf5_io.py::test_unified_read_hdf5_reads_crossvalidated_baseline_model \
+  tests/test_hdf5_io.py::test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg \
+  tests/test_hdf5_io.py::test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg_bypasses_cache \
+  -v
+```
+
+Expected: all FAIL — `CrossvalidatedBaselineModel` not in `_MODEL_READERS`.
+
+- [ ] **Step 4: Update `pysaliency/hdf5.py`**
+
+Add `_read_crossvalidated_baseline_model` after `_read_baseline_model`, then **replace** the existing `_MODEL_READERS` dict definition with the extended version:
+
+```python
+def _read_crossvalidated_baseline_model(source, **kwargs):
+    from .baseline_utils import CrossvalidatedBaselineModel
+    return CrossvalidatedBaselineModel.read_hdf5(source, **kwargs)
+
+
+_MODEL_READERS = {
+    'pysaliency.baseline_utils.BaselineModel': _read_baseline_model,
+    'pysaliency.baseline_utils.CrossvalidatedBaselineModel': _read_crossvalidated_baseline_model,
+}
+```
+
+- [ ] **Step 5: Run all three dispatcher tests**
+
+```bash
+python -m pytest --nomatlab \
+  tests/test_hdf5_io.py::test_unified_read_hdf5_reads_crossvalidated_baseline_model \
+  tests/test_hdf5_io.py::test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg \
+  tests/test_hdf5_io.py::test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg_bypasses_cache \
+  -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+python -m pytest --nomatlab tests/ -v
+```
+
+Expected: all pass. Fix any regressions before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pysaliency/hdf5.py tests/test_hdf5_io.py
+git commit -m "feat: register CrossvalidatedBaselineModel in pysaliency.read_hdf5 dispatcher"
+```

--- a/docs/superpowers/specs/2026-03-21-model-hdf5-save-reload-design.md
+++ b/docs/superpowers/specs/2026-03-21-model-hdf5-save-reload-design.md
@@ -1,0 +1,118 @@
+# Design: HDF5 Save/Reload for Saliency Models
+
+**Date:** 2026-03-21
+**Branch:** enh-save-baseline-model-to-hdf5
+**Status:** Approved
+
+## Background
+
+`pysaliency.export_model_to_hdf5` serializes model *predictions* (saliency maps) for every stimulus into an HDF5 file. For large stimulus sets this produces huge files. For models that are fast to compute (e.g. kernel density baseline models), it is preferable to serialize the model *parameters* instead, so the model can be reconstructed and run on demand.
+
+The datasets module already has a mature `to_hdf5` / `read_hdf5` pattern per class, with a unified `pysaliency.datasets.read_hdf5` dispatcher. This design extends that pattern to models.
+
+## Scope
+
+- `BaselineModel`: already implemented in the current branch (no changes needed)
+- `CrossvalidatedBaselineModel`: new, covered by this spec
+- `pysaliency.read_hdf5`: unified dispatcher (already partially implemented); document `**kwargs` passthrough contract
+
+Out of scope: other model types (`GoldModel`, `KDEGoldModel`, etc.) — follow the same pattern incrementally.
+
+## Key Constraints
+
+- **Stimulus IDs are not stable across systems.** SHA1 hashes of pixel data differ between libjpeg versions. Saving only `stimulus_ids` (Option B) was considered and rejected: it silently breaks when a system update changes JPEG decoding. Full stimulus data must be embedded, or the caller must supply stimuli explicitly at load time.
+- **Stimuli can be large.** Embedding raw pixel arrays for large datasets is expensive. A flag controls whether stimuli are embedded, analogous to `BaselineModel`'s `include_shape_cache`.
+
+## Design
+
+### `BaselineModel` (existing — no changes)
+
+Saves to HDF5:
+- `attrs['type'] = 'pysaliency.baseline_utils.BaselineModel'`
+- `attrs['version'] = '1.0'`
+- `attrs['bandwidth']`, `attrs['eps']`, `attrs['keep_aspect']`
+- dataset `xs`, dataset `ys` — normalized fixation coordinates
+- optional group `shape_cache` — precomputed log-density maps per image shape (controlled by `include_shape_cache=True`, default `True`)
+
+No reference to stimuli or fixations is stored; the model is self-contained.
+
+### `CrossvalidatedBaselineModel`
+
+#### `to_hdf5(target, include_stimuli=True)`
+
+Uses the existing `@hdf5_wrapper(mode='w')` decorator for transparent file/group dispatch.
+
+Saves:
+- `attrs['type'] = 'pysaliency.baseline_utils.CrossvalidatedBaselineModel'`
+- `attrs['version'] = '1.0'`
+- `attrs['bandwidth']`, `attrs['eps']`
+- dataset `xs`, dataset `ys` — normalized fixation coordinates
+- dataset `fixations_n` — `self.fixations.n` (integer array mapping each fixation to its stimulus index)
+- group `stimuli` — embedded via `self.stimuli.to_hdf5(target.create_group('stimuli'))` — **only when `include_stimuli=True`**
+
+When `include_stimuli=False`, the `stimuli` group is omitted entirely; the file is not self-contained and requires `stimuli=` at load time.
+
+#### `read_hdf5(source, *, stimuli=None, caching=True, memory_cache_size=None, cache_location=None)`
+
+Classmethod, uses `@hdf5_wrapper(mode='r')`.
+
+Load order:
+1. Validate `type` and `version` attrs
+2. Resolve stimuli:
+   - If `stimuli` kwarg is provided → use it (ignore embedded group even if present)
+   - Else if `'stimuli'` group exists in file → load via `pysaliency.datasets.read_hdf5`
+   - Else → raise `ValueError("No stimuli found in HDF5 file. Pass `stimuli=` explicitly.")`
+3. Reconstruct model via `cls.__new__(cls)` + `Model.__init__(...)` (same pattern as `BaselineModel`)
+4. Restore `bandwidth`, `eps`, `xs`, `ys`, `fixations.n` (stored as a plain struct with `.n` attribute, or just as an array assigned to `self.fixations` with a `.n` property — see Implementation Notes)
+
+#### Registration
+
+`pysaliency/hdf5.py` `_MODEL_READERS`:
+
+```python
+_MODEL_READERS = {
+    'pysaliency.baseline_utils.BaselineModel': _read_baseline_model,
+    'pysaliency.baseline_utils.CrossvalidatedBaselineModel': _read_crossvalidated_baseline_model,
+}
+```
+
+where `_read_crossvalidated_baseline_model` is a thin wrapper that delegates to `CrossvalidatedBaselineModel.read_hdf5`.
+
+### `pysaliency.read_hdf5` dispatcher
+
+The dispatcher already accepts and passes through `**kwargs` to the class-specific reader. This is the correct contract — `read_hdf5` remains a thin dispatcher with no knowledge of model-specific parameters.
+
+Usage:
+```python
+# Self-contained file — no kwargs needed
+model = pysaliency.read_hdf5('model.hdf5')
+
+# File saved without stimuli — pass them through **kwargs
+model = pysaliency.read_hdf5('model.hdf5', stimuli=my_stimuli)
+
+# Canonical class-level API (always available)
+model = CrossvalidatedBaselineModel.read_hdf5('model.hdf5', stimuli=my_stimuli)
+```
+
+### `pysaliency.__init__` exports
+
+`read_hdf5` is added to the top-level `pysaliency` namespace (already in progress on this branch).
+
+## Implementation Notes
+
+- `CrossvalidatedBaselineModel._log_density` currently references `self.stimuli` (for `stimulus_ids`) and `self.fixations.n`. After deserialization, `self.stimuli` is the resolved stimuli object and `self.fixations` needs a `.n` attribute. The simplest approach is a small namedtuple or dataclass `_FixationsN` with just a `.n` field, avoiding a full `Fixations` object dependency. Alternatively, store `fixations_n` directly as `self._fixations_n` and update `_log_density` accordingly — this is a minor internal refactor, not a public API change.
+- `hdf5_wrapper` currently handles `self` as the first argument (instance methods). For classmethods, `BaselineModel` uses `@classmethod` + `@hdf5_wrapper` stacked — the same pattern applies to `CrossvalidatedBaselineModel`.
+- When stimuli are embedded as raw numpy arrays (via `Stimuli.to_hdf5`), hashes computed at reload time are stable. When the caller passes `FileStimuli` and JPEG decoding differs across systems, they must provide `stimuli=` explicitly to ensure hash consistency.
+
+## Tests
+
+All tests go in `tests/test_baseline_utils.py` (existing file) and `tests/test_hdf5_io.py`:
+
+| Test | File |
+|------|------|
+| Roundtrip `CrossvalidatedBaselineModel` with `include_stimuli=True` | `test_baseline_utils.py` |
+| Roundtrip `CrossvalidatedBaselineModel` with `include_stimuli=False` + explicit `stimuli=` | `test_baseline_utils.py` |
+| `ValueError` when `include_stimuli=False` and no `stimuli=` on reload | `test_baseline_utils.py` |
+| `type` attr is `'pysaliency.baseline_utils.CrossvalidatedBaselineModel'` | `test_baseline_utils.py` |
+| `pysaliency.read_hdf5` dispatcher round-trips `CrossvalidatedBaselineModel` | `test_hdf5_io.py` |
+| `pysaliency.read_hdf5` with `stimuli=` kwarg passthrough | `test_hdf5_io.py` |

--- a/docs/superpowers/specs/2026-03-21-model-hdf5-save-reload-design.md
+++ b/docs/superpowers/specs/2026-03-21-model-hdf5-save-reload-design.md
@@ -38,6 +38,21 @@ No reference to stimuli or fixations is stored; the model is self-contained.
 
 ### `CrossvalidatedBaselineModel`
 
+#### Internal refactor: store `fixations_n` directly
+
+As part of this work, `CrossvalidatedBaselineModel.__init__` is refactored to store only the fixation index array rather than the full `fixations` object:
+
+```python
+# Before
+self.fixations = fixations
+self.shape_cache = {}   # unused — remove
+
+# After
+self.fixations_n = fixations.n.copy()
+```
+
+`_log_density` is updated accordingly: `self.fixations.n` → `self.fixations_n`. This makes the model's stored state minimal and eliminates any need for workarounds during deserialization.
+
 #### `to_hdf5(target, include_stimuli=True)`
 
 Uses the existing `@hdf5_wrapper(mode='w')` decorator for transparent file/group dispatch.
@@ -45,25 +60,31 @@ Uses the existing `@hdf5_wrapper(mode='w')` decorator for transparent file/group
 Saves:
 - `attrs['type'] = 'pysaliency.baseline_utils.CrossvalidatedBaselineModel'`
 - `attrs['version'] = '1.0'`
-- `attrs['bandwidth']`, `attrs['eps']`
+- `attrs['bandwidth']`, `attrs['eps']` — note: no `keep_aspect`, no `shape_cache`
 - dataset `xs`, dataset `ys` — normalized fixation coordinates
-- dataset `fixations_n` — `self.fixations.n` (integer array mapping each fixation to its stimulus index)
+- dataset `fixations_n` — `self.fixations_n` (integer array mapping each fixation to its stimulus index)
 - group `stimuli` — embedded via `self.stimuli.to_hdf5(target.create_group('stimuli'))` — **only when `include_stimuli=True`**
 
 When `include_stimuli=False`, the `stimuli` group is omitted entirely; the file is not self-contained and requires `stimuli=` at load time.
 
 #### `read_hdf5(source, *, stimuli=None, caching=True, memory_cache_size=None, cache_location=None)`
 
-Classmethod, uses `@hdf5_wrapper(mode='r')`.
+Classmethod. Decorator stacking must match `BaselineModel` exactly: `@classmethod` outermost, `@hdf5_wrapper(mode='r')` inner.
 
 Load order:
-1. Validate `type` and `version` attrs
+1. Validate `type` and `version` attrs. Raise `ValueError` if `type` is not `'pysaliency.baseline_utils.CrossvalidatedBaselineModel'` or `version` is not `'1.0'`.
 2. Resolve stimuli:
    - If `stimuli` kwarg is provided → use it (ignore embedded group even if present)
-   - Else if `'stimuli'` group exists in file → load via `pysaliency.datasets.read_hdf5`
-   - Else → raise `ValueError("No stimuli found in HDF5 file. Pass `stimuli=` explicitly.")`
+   - Else if `'stimuli'` group exists in file → load via `pysaliency.hdf5.read_hdf5(source['stimuli'])`
+   - Else → raise `ValueError("No stimuli found in HDF5 file. Pass stimuli= explicitly.")`
 3. Reconstruct model via `cls.__new__(cls)` + `Model.__init__(...)` (same pattern as `BaselineModel`)
-4. Restore `bandwidth`, `eps`, `xs`, `ys`, `fixations.n` (stored as a plain struct with `.n` attribute, or just as an array assigned to `self.fixations` with a `.n` property — see Implementation Notes)
+4. Restore fields:
+   - `model.bandwidth = source.attrs['bandwidth']`
+   - `model.eps = source.attrs['eps']`
+   - `model.xs = source['xs'][...]`
+   - `model.ys = source['ys'][...]`
+   - `model.fixations_n = source['fixations_n'][...]`
+   - `model.stimuli = stimuli` (resolved above)
 
 #### Registration
 
@@ -100,9 +121,11 @@ model = CrossvalidatedBaselineModel.read_hdf5('model.hdf5', stimuli=my_stimuli)
 
 ## Implementation Notes
 
-- `CrossvalidatedBaselineModel._log_density` currently references `self.stimuli` (for `stimulus_ids`) and `self.fixations.n`. After deserialization, `self.stimuli` is the resolved stimuli object and `self.fixations` needs a `.n` attribute. The simplest approach is a small namedtuple or dataclass `_FixationsN` with just a `.n` field, avoiding a full `Fixations` object dependency. Alternatively, store `fixations_n` directly as `self._fixations_n` and update `_log_density` accordingly — this is a minor internal refactor, not a public API change.
-- `hdf5_wrapper` currently handles `self` as the first argument (instance methods). For classmethods, `BaselineModel` uses `@classmethod` + `@hdf5_wrapper` stacked — the same pattern applies to `CrossvalidatedBaselineModel`.
-- When stimuli are embedded as raw numpy arrays (via `Stimuli.to_hdf5`), hashes computed at reload time are stable. When the caller passes `FileStimuli` and JPEG decoding differs across systems, they must provide `stimuli=` explicitly to ensure hash consistency.
+- **`CrossvalidatedBaselineModel` refactor** is an internal change. The public constructor signature `__init__(self, stimuli, fixations, bandwidth, eps)` is unchanged; only the stored attributes change (`self.fixations_n` replaces `self.fixations`, `self.shape_cache` is removed). This is not a breaking change.
+- **`hdf5_wrapper` + `@classmethod` ordering:** `@classmethod` must be the outermost decorator and `@hdf5_wrapper(mode='r')` the inner one — exactly as in `BaselineModel.read_hdf5`. Reversing the order will fail.
+- **WeakValueDictionary cache in `pysaliency.read_hdf5`:** The top-level `_read_hdf5_from_file` is cached via `boltons.cacheutils.cached`. Since `boltons` does not include `**kwargs` in the cache key, passing `stimuli=` via `pysaliency.read_hdf5('model.hdf5', stimuli=X)` on a second call would return the cached model from the first call. The existing fallback path (lines 43–45 of `hdf5.py`) bypasses the cache when `kwargs` are not hashable — but a numpy array for `stimuli` is not hashable, so the fallback triggers correctly. This is worth an explicit test to guard against regressions.
+- **Stimuli hash stability:** Hash consistency requires that the embedded stimuli and the stimuli passed to `_log_density` are decoded via the same code path. If both are `FileStimuli` pointing to the same JPEG files, hashes will match even across libjpeg updates (both sides re-decode with the same updated library). A mismatch only arises when the two sides use different decoding paths — e.g., stimuli embedded as raw numpy arrays in HDF5 but evaluated with freshly JPEG-decoded `FileStimuli`, or vice versa. In such cases `stimuli=` must be passed explicitly on reload.
+- **Unknown stimulus at inference time:** If a stimulus is passed to `_log_density` that was not in the training set, `self.stimuli.stimulus_ids.index(stimulus_id)` raises `ValueError`. This is existing behavior and is not changed by this design.
 
 ## Tests
 
@@ -110,9 +133,9 @@ All tests go in `tests/test_baseline_utils.py` (existing file) and `tests/test_h
 
 | Test | File |
 |------|------|
-| Roundtrip `CrossvalidatedBaselineModel` with `include_stimuli=True` | `test_baseline_utils.py` |
-| Roundtrip `CrossvalidatedBaselineModel` with `include_stimuli=False` + explicit `stimuli=` | `test_baseline_utils.py` |
+| Roundtrip `CrossvalidatedBaselineModel` with `include_stimuli=True` — numerical equality of log-density | `test_baseline_utils.py` |
+| Roundtrip `CrossvalidatedBaselineModel` with `include_stimuli=False` + explicit `stimuli=` — numerical equality | `test_baseline_utils.py` |
 | `ValueError` when `include_stimuli=False` and no `stimuli=` on reload | `test_baseline_utils.py` |
 | `type` attr is `'pysaliency.baseline_utils.CrossvalidatedBaselineModel'` | `test_baseline_utils.py` |
 | `pysaliency.read_hdf5` dispatcher round-trips `CrossvalidatedBaselineModel` | `test_hdf5_io.py` |
-| `pysaliency.read_hdf5` with `stimuli=` kwarg passthrough | `test_hdf5_io.py` |
+| `pysaliency.read_hdf5` with `stimuli=` kwarg passthrough bypasses WeakValueDictionary cache | `test_hdf5_io.py` |

--- a/pysaliency/__init__.py
+++ b/pysaliency/__init__.py
@@ -6,6 +6,7 @@ from . import models
 from . import external_models
 from . import external_datasets
 from . import utils
+from .hdf5 import read_hdf5
 
 from .datasets import (
     Fixations,
@@ -18,7 +19,6 @@ from .datasets import (
     create_subset,
     remove_out_of_stimulus_fixations,
     concatenate_datasets,
-    read_hdf5,
 )
 from .dataset_config import load_dataset_from_config
 from .saliency_map_models import (

--- a/pysaliency/baseline_utils.py
+++ b/pysaliency/baseline_utils.py
@@ -11,6 +11,7 @@ from sklearn.model_selection import cross_val_score
 from sklearn.neighbors import KernelDensity
 
 from . import Model, UniformModel
+from .datasets.utils import decode_string, hdf5_wrapper
 from .numba_utils import fill_fixation_map
 from .precomputed_models import get_image_hash
 from .roc import general_roc
@@ -556,15 +557,13 @@ class KDEGoldModel(Model):
 
 
 class CrossvalidatedBaselineModel(Model):
-    def __init__(self, stimuli, fixations, bandwidth, eps = 1e-20, **kwargs):
+    def __init__(self, stimuli, fixations, bandwidth, eps=1e-20, **kwargs):
         super(CrossvalidatedBaselineModel, self).__init__(**kwargs)
         self.stimuli = stimuli
-        self.fixations = fixations
         self.bandwidth = bandwidth
         self.eps = eps
         self.xs, self.ys = normalize_fixations(stimuli, fixations)
-        #self.kde = KernelDensity(kernel='gaussian', bandwidth=bandwidth).fit(np.vstack([self.xs, self.ys]).T)
-        self.shape_cache = {}
+        self.fixations_n = fixations.n.copy()
 
     def _log_density(self, stimulus):
         shape = stimulus.shape[0], stimulus.shape[1]
@@ -572,8 +571,7 @@ class CrossvalidatedBaselineModel(Model):
         stimulus_id = get_image_hash(stimulus)
         stimulus_index = self.stimuli.stimulus_ids.index(stimulus_id)
 
-        #fixations = self.fixations[self.fixations.n == stimulus_index]
-        inds = self.fixations.n != stimulus_index
+        inds = self.fixations_n != stimulus_index
 
         ZZ = np.zeros(shape)
 
@@ -585,7 +583,6 @@ class CrossvalidatedBaselineModel(Model):
         ZZ = np.log(ZZ)
 
         ZZ -= logsumexp(ZZ)
-        #ZZ -= np.log(np.exp(ZZ).sum())
 
         return ZZ
 
@@ -593,13 +590,63 @@ class CrossvalidatedBaselineModel(Model):
 class BaselineModel(Model):
     def __init__(self, stimuli, fixations, bandwidth, eps = 1e-20, keep_aspect=False, **kwargs):
         super(BaselineModel, self).__init__(**kwargs)
-        self.stimuli = stimuli
-        self.fixations = fixations
         self.bandwidth = bandwidth
         self.eps = eps
         self.keep_aspect = keep_aspect
         self.xs, self.ys = normalize_fixations(stimuli, fixations, keep_aspect=keep_aspect)
         self.shape_cache = {}
+
+    @hdf5_wrapper(mode='w')
+    def to_hdf5(self, target, include_shape_cache=True):
+        target.attrs['type'] = np.bytes_('pysaliency.baseline_utils.BaselineModel')
+        target.attrs['version'] = np.bytes_('1.0')
+        target.attrs['bandwidth'] = self.bandwidth
+        target.attrs['eps'] = self.eps
+        target.attrs['keep_aspect'] = self.keep_aspect
+        target.create_dataset('xs', data=self.xs)
+        target.create_dataset('ys', data=self.ys)
+
+        if include_shape_cache:
+            shape_cache_group = target.create_group('shape_cache')
+            for shape, value in self.shape_cache.items():
+                shape_key = f"{shape[0]},{shape[1]}"
+                shape_cache_group.create_dataset(shape_key, data=value)
+
+    @classmethod
+    @hdf5_wrapper(mode='r')
+    def read_hdf5(
+        cls,
+        source,
+        *,
+        caching=True,
+        memory_cache_size=None,
+        cache_location=None,
+        reset_shape_cache=False,
+    ):
+        data_type = decode_string(source.attrs['type'])
+        data_version = decode_string(source.attrs['version'])
+
+        if data_type != 'pysaliency.baseline_utils.BaselineModel':
+            raise ValueError("Invalid type! Expected 'pysaliency.baseline_utils.BaselineModel', got", data_type)
+        if data_version != '1.0':
+            raise ValueError("Invalid version! Expected '1.0', got", data_version)
+
+        model = cls.__new__(cls)
+        Model.__init__(model, cache_location=cache_location, caching=caching, memory_cache_size=memory_cache_size)
+        model.bandwidth = source.attrs['bandwidth']
+        model.eps = source.attrs['eps']
+        model.keep_aspect = bool(source.attrs['keep_aspect'])
+        model.xs = source['xs'][...]
+        model.ys = source['ys'][...]
+        model.shape_cache = {}
+
+        if not reset_shape_cache and 'shape_cache' in source:
+            shape_cache_group = source['shape_cache']
+            for shape_key in shape_cache_group.keys():
+                shape = tuple(int(value) for value in shape_key.split(','))
+                model.shape_cache[shape] = shape_cache_group[shape_key][...]
+
+        return model
 
     def _log_density(self, stimulus):
         shape = stimulus.shape[0], stimulus.shape[1]

--- a/pysaliency/baseline_utils.py
+++ b/pysaliency/baseline_utils.py
@@ -586,6 +586,20 @@ class CrossvalidatedBaselineModel(Model):
 
         return ZZ
 
+    @hdf5_wrapper(mode='w')
+    def to_hdf5(self, target, include_stimuli=True):
+        target.attrs['type'] = np.bytes_('pysaliency.baseline_utils.CrossvalidatedBaselineModel')
+        target.attrs['version'] = np.bytes_('1.0')
+        target.attrs['bandwidth'] = self.bandwidth
+        target.attrs['eps'] = self.eps
+        target.create_dataset('xs', data=self.xs)
+        target.create_dataset('ys', data=self.ys)
+        target.create_dataset('fixations_n', data=self.fixations_n)
+
+        if include_stimuli:
+            stimuli_group = target.create_group('stimuli')
+            self.stimuli.to_hdf5(stimuli_group)
+
 
 class BaselineModel(Model):
     def __init__(self, stimuli, fixations, bandwidth, eps = 1e-20, keep_aspect=False, **kwargs):

--- a/pysaliency/baseline_utils.py
+++ b/pysaliency/baseline_utils.py
@@ -600,6 +600,45 @@ class CrossvalidatedBaselineModel(Model):
             stimuli_group = target.create_group('stimuli')
             self.stimuli.to_hdf5(stimuli_group)
 
+    @classmethod
+    @hdf5_wrapper(mode='r')
+    def read_hdf5(
+        cls,
+        source,
+        *,
+        stimuli=None,
+        caching=True,
+        memory_cache_size=None,
+        cache_location=None,
+    ):
+        from .hdf5 import read_hdf5 as _read_hdf5
+
+        data_type = decode_string(source.attrs['type'])
+        data_version = decode_string(source.attrs['version'])
+
+        if data_type != 'pysaliency.baseline_utils.CrossvalidatedBaselineModel':
+            raise ValueError("Invalid type! Expected 'pysaliency.baseline_utils.CrossvalidatedBaselineModel', got", data_type)
+        if data_version != '1.0':
+            raise ValueError("Invalid version! Expected '1.0', got", data_version)
+
+        if stimuli is None:
+            if 'stimuli' not in source:
+                raise ValueError(
+                    "No stimuli found in HDF5 file. Pass stimuli= explicitly."
+                )
+            stimuli = _read_hdf5(source['stimuli'])
+
+        model = cls.__new__(cls)
+        Model.__init__(model, cache_location=cache_location, caching=caching, memory_cache_size=memory_cache_size)
+        model.bandwidth = source.attrs['bandwidth']
+        model.eps = source.attrs['eps']
+        model.xs = source['xs'][...]
+        model.ys = source['ys'][...]
+        model.fixations_n = source['fixations_n'][...]
+        model.stimuli = stimuli
+
+        return model
+
 
 class BaselineModel(Model):
     def __init__(self, stimuli, fixations, bandwidth, eps = 1e-20, keep_aspect=False, **kwargs):

--- a/pysaliency/datasets/__init__.py
+++ b/pysaliency/datasets/__init__.py
@@ -1,43 +1,16 @@
-import pathlib
 from typing import Dict, List, Optional, Union
-from weakref import WeakValueDictionary
 
 import numpy as np
-from boltons.cacheutils import cached
 
+from ..hdf5 import read_hdf5 as _read_hdf5
 from .fixations import Fixations, FixationTrains, ScanpathFixations, scanpaths_from_fixations
 from .scanpaths import Scanpaths, concatenate_scanpaths
 from .stimuli import FileStimuli, ObjectStimuli, Stimuli, StimuliStimulus, Stimulus, as_stimulus, check_prediction_shape, get_image_hash
-from .utils import concatenate_attributes, decode_string, get_merged_attribute_list
-
-
-@cached(WeakValueDictionary())
-def _read_hdf5_from_file(source, **kwargs):
-    import h5py
-    with h5py.File(source, 'r') as hdf5_file:
-        return read_hdf5(hdf5_file, **kwargs)
+from .utils import concatenate_attributes, get_merged_attribute_list
 
 
 def read_hdf5(source, **kwargs):
-    if isinstance(source, (str, pathlib.Path)):
-        return _read_hdf5_from_file(source, **kwargs)
-
-    data_type = decode_string(source.attrs['type'])
-
-    if data_type == 'Fixations':
-        return Fixations.read_hdf5(source, **kwargs)
-    elif data_type == 'ScanpathFixations':
-        return ScanpathFixations.read_hdf5(source, **kwargs)
-    elif data_type == 'FixationTrains':
-        return FixationTrains.read_hdf5(source, **kwargs)
-    elif data_type == 'Scanpaths':
-        return Scanpaths.read_hdf5(source, **kwargs)
-    elif data_type == 'Stimuli':
-        return Stimuli.read_hdf5(source, **kwargs)
-    elif data_type == 'FileStimuli':
-        return FileStimuli.read_hdf5(source, **kwargs)
-    else:
-        raise ValueError("Invalid HDF content type:", data_type)
+    return _read_hdf5(source, _expected_kind='dataset', **kwargs)
 
 
 def create_subset(stimuli, fixations, stimuli_indices):

--- a/pysaliency/hdf5.py
+++ b/pysaliency/hdf5.py
@@ -1,0 +1,66 @@
+import pathlib
+from weakref import WeakValueDictionary
+
+from boltons.cacheutils import cached
+
+from .datasets.fixations import Fixations, FixationTrains, ScanpathFixations
+from .datasets.scanpaths import Scanpaths
+from .datasets.stimuli import FileStimuli, Stimuli
+from .datasets.utils import decode_string
+
+
+@cached(WeakValueDictionary())
+def _read_hdf5_from_file(source, **kwargs):
+    import h5py
+    with h5py.File(source, 'r') as hdf5_file:
+        return read_hdf5(hdf5_file, **kwargs)
+
+
+def _read_baseline_model(source, **kwargs):
+    from .baseline_utils import BaselineModel
+    return BaselineModel.read_hdf5(source, **kwargs)
+
+
+def _read_crossvalidated_baseline_model(source, **kwargs):
+    from .baseline_utils import CrossvalidatedBaselineModel
+    return CrossvalidatedBaselineModel.read_hdf5(source, **kwargs)
+
+
+_DATASET_READERS = {
+    'Fixations': Fixations.read_hdf5,
+    'ScanpathFixations': ScanpathFixations.read_hdf5,
+    'FixationTrains': FixationTrains.read_hdf5,
+    'Scanpaths': Scanpaths.read_hdf5,
+    'Stimuli': Stimuli.read_hdf5,
+    'FileStimuli': FileStimuli.read_hdf5,
+}
+
+_MODEL_READERS = {
+    'pysaliency.baseline_utils.BaselineModel': _read_baseline_model,
+    'pysaliency.baseline_utils.CrossvalidatedBaselineModel': _read_crossvalidated_baseline_model,
+}
+
+
+def read_hdf5(source, hdf5_kwargs=None, _expected_kind=None, **kwargs):
+    if isinstance(source, (str, pathlib.Path)):
+        try:
+            return _read_hdf5_from_file(source, hdf5_kwargs=hdf5_kwargs, _expected_kind=_expected_kind, **kwargs)
+        except TypeError:
+            import h5py
+            with h5py.File(source, 'r') as hdf5_file:
+                return read_hdf5(hdf5_file, hdf5_kwargs=hdf5_kwargs, _expected_kind=_expected_kind, **kwargs)
+
+    if hdf5_kwargs:
+        raise NotImplementedError("Nested `hdf5_kwargs` routing is not implemented yet.")
+
+    data_type = decode_string(source.attrs['type'])
+    if data_type in _DATASET_READERS:
+        if _expected_kind == 'model':
+            raise ValueError("Invalid HDF model type:", data_type)
+        return _DATASET_READERS[data_type](source, **kwargs)
+    if data_type in _MODEL_READERS:
+        if _expected_kind == 'dataset':
+            raise ValueError("Invalid HDF dataset type:", data_type)
+        return _MODEL_READERS[data_type](source, **kwargs)
+
+    raise ValueError("Invalid HDF content type:", data_type)

--- a/tests/test_baseline_utils.py
+++ b/tests/test_baseline_utils.py
@@ -224,3 +224,48 @@ def test_crossvalidated_baseline_model_hdf5_type(tmp_path, stimuli, scanpath_fix
         if not isinstance(value, str):
             value = value.decode('utf8')
         assert value == 'pysaliency.baseline_utils.CrossvalidatedBaselineModel'
+
+
+def test_crossvalidated_baseline_model_hdf5_roundtrip_with_stimuli(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    first_prediction = model.log_density(stimuli[0]).copy()
+
+    path = tmp_path / 'cv_baseline.hdf5'
+    model.to_hdf5(path)
+
+    reloaded = CrossvalidatedBaselineModel.read_hdf5(path)
+    np.testing.assert_allclose(reloaded.log_density(stimuli[0]), first_prediction)
+
+
+def test_crossvalidated_baseline_model_hdf5_roundtrip_without_stimuli(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    first_prediction = model.log_density(stimuli[1]).copy()
+
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    reloaded = CrossvalidatedBaselineModel.read_hdf5(path, stimuli=stimuli)
+    np.testing.assert_allclose(reloaded.log_density(stimuli[1]), first_prediction)
+
+
+def test_crossvalidated_baseline_model_hdf5_error_without_stimuli(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    with pytest.raises(ValueError, match='stimuli'):
+        CrossvalidatedBaselineModel.read_hdf5(path)
+
+
+def test_crossvalidated_baseline_model_hdf5_stimuli_kwarg_overrides_embedded(tmp_path, stimuli, scanpath_fixations):
+    """stimuli= kwarg takes precedence over the embedded stimuli group."""
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    first_prediction = model.log_density(stimuli[0]).copy()
+
+    path = tmp_path / 'cv_baseline_with_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=True)
+
+    # Pass the same stimuli explicitly — should still work (kwarg wins)
+    reloaded = CrossvalidatedBaselineModel.read_hdf5(path, stimuli=stimuli)
+    assert reloaded.stimuli is stimuli
+    np.testing.assert_allclose(reloaded.log_density(stimuli[0]), first_prediction)

--- a/tests/test_baseline_utils.py
+++ b/tests/test_baseline_utils.py
@@ -7,6 +7,8 @@ import pytest
 
 import pysaliency
 from pysaliency.baseline_utils import (
+    BaselineModel,
+    CrossvalidatedBaselineModel,
     CrossvalMultipleRegularizations,
     GeneralMixtureKernelDensityEstimator,
     KDEGoldModel,
@@ -156,3 +158,56 @@ def test_crossval_multiple_regularizations(stimuli, scanpath_fixations):
     score = estimator.score(log_bandwidth, *log_regularizations)
     assert isinstance(score, float)
     np.testing.assert_allclose(score, -1.4673831679692528e-10)
+
+
+def test_baseline_model_does_not_store_stimuli_and_fixations(stimuli, scanpath_fixations):
+    model = BaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    assert not hasattr(model, 'stimuli')
+    assert not hasattr(model, 'fixations')
+
+
+def test_baseline_model_hdf5_roundtrip_with_shape_cache(tmp_path, stimuli, scanpath_fixations):
+    model = BaselineModel(stimuli, scanpath_fixations, bandwidth=0.1, keep_aspect=True)
+    first_prediction = model.log_density(stimuli[0]).copy()
+    assert stimuli[0].shape[:2] in model.shape_cache
+
+    path = tmp_path / 'baseline_model.hdf5'
+    model.to_hdf5(path, include_shape_cache=True)
+
+    reloaded = BaselineModel.read_hdf5(path)
+    np.testing.assert_allclose(reloaded.log_density(stimuli[0]), first_prediction)
+    assert stimuli[0].shape[:2] in reloaded.shape_cache
+
+
+def test_baseline_model_hdf5_roundtrip_without_shape_cache(tmp_path, stimuli, scanpath_fixations):
+    model = BaselineModel(stimuli, scanpath_fixations, bandwidth=0.2)
+    first_prediction = model.log_density(stimuli[1]).copy()
+
+    path = tmp_path / 'baseline_model_no_cache.hdf5'
+    model.to_hdf5(path, include_shape_cache=False)
+
+    reloaded = BaselineModel.read_hdf5(path)
+    assert reloaded.shape_cache == {}
+    np.testing.assert_allclose(reloaded.log_density(stimuli[1]), first_prediction)
+
+
+def test_baseline_model_hdf5_type(tmp_path, stimuli, scanpath_fixations):
+    model = BaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    path = tmp_path / 'baseline_type.hdf5'
+    model.to_hdf5(path)
+
+    import h5py
+
+    with h5py.File(path, 'r') as hdf5_file:
+        value = hdf5_file.attrs['type']
+        if not isinstance(value, str):
+            value = value.decode('utf8')
+        assert value == 'pysaliency.baseline_utils.BaselineModel'
+
+
+def test_crossvalidated_baseline_model_stores_fixations_n(stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    assert hasattr(model, 'fixations_n')
+    assert not hasattr(model, 'fixations')
+    assert not hasattr(model, 'shape_cache')
+    np.testing.assert_array_equal(model.fixations_n, scanpath_fixations.n)

--- a/tests/test_baseline_utils.py
+++ b/tests/test_baseline_utils.py
@@ -211,3 +211,16 @@ def test_crossvalidated_baseline_model_stores_fixations_n(stimuli, scanpath_fixa
     assert not hasattr(model, 'fixations')
     assert not hasattr(model, 'shape_cache')
     np.testing.assert_array_equal(model.fixations_n, scanpath_fixations.n)
+
+
+def test_crossvalidated_baseline_model_hdf5_type(tmp_path, stimuli, scanpath_fixations):
+    model = CrossvalidatedBaselineModel(stimuli, scanpath_fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_type.hdf5'
+    model.to_hdf5(path)
+
+    import h5py
+    with h5py.File(path, 'r') as f:
+        value = f.attrs['type']
+        if not isinstance(value, str):
+            value = value.decode('utf8')
+        assert value == 'pysaliency.baseline_utils.CrossvalidatedBaselineModel'

--- a/tests/test_hdf5_io.py
+++ b/tests/test_hdf5_io.py
@@ -1,0 +1,105 @@
+import numpy as np
+
+import pysaliency
+from pysaliency.baseline_utils import BaselineModel, CrossvalidatedBaselineModel
+
+
+def test_unified_read_hdf5_reads_dataset_files(tmp_path):
+    stimuli = pysaliency.Stimuli([np.random.randn(12, 10, 3), np.random.randn(8, 9, 3)])
+    path = tmp_path / 'stimuli.hdf5'
+    stimuli.to_hdf5(path)
+
+    loaded = pysaliency.read_hdf5(path)
+    assert isinstance(loaded, pysaliency.Stimuli)
+    assert len(loaded) == len(stimuli)
+    np.testing.assert_array_equal(loaded[0].stimulus_data, stimuli[0].stimulus_data)
+
+
+def test_unified_read_hdf5_reads_baseline_model_files(tmp_path):
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = BaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'baseline_model.hdf5'
+    model.to_hdf5(path)
+
+    loaded = pysaliency.read_hdf5(path)
+    assert isinstance(loaded, BaselineModel)
+    np.testing.assert_allclose(loaded.log_density(stimuli[0]), model.log_density(stimuli[0]))
+
+
+def test_legacy_datasets_read_hdf5_wrapper_still_works(tmp_path):
+    stimuli = pysaliency.Stimuli([np.random.randn(15, 10, 3)])
+    path = tmp_path / 'stimuli_legacy.hdf5'
+    stimuli.to_hdf5(path)
+
+    loaded = pysaliency.datasets.read_hdf5(path)
+    assert isinstance(loaded, pysaliency.Stimuli)
+    np.testing.assert_array_equal(loaded[0].stimulus_data, stimuli[0].stimulus_data)
+
+
+def test_unified_read_hdf5_reads_crossvalidated_baseline_model(tmp_path):
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = CrossvalidatedBaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_model.hdf5'
+    model.to_hdf5(path)
+
+    loaded = pysaliency.read_hdf5(path)
+    assert isinstance(loaded, CrossvalidatedBaselineModel)
+    np.testing.assert_allclose(loaded.log_density(stimuli[0]), model.log_density(stimuli[0]))
+
+
+def test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg(tmp_path):
+    """stimuli= kwarg is forwarded correctly through the dispatcher."""
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = CrossvalidatedBaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    loaded = pysaliency.read_hdf5(str(path), stimuli=stimuli)
+    assert isinstance(loaded, CrossvalidatedBaselineModel)
+    assert loaded.stimuli is stimuli
+    np.testing.assert_allclose(loaded.log_density(stimuli[0]), model.log_density(stimuli[0]))
+
+
+def test_unified_read_hdf5_crossvalidated_baseline_model_stimuli_kwarg_bypasses_cache(tmp_path):
+    """Regression: stimuli= kwarg must bypass WeakValueDictionary cache in _read_hdf5_from_file."""
+    stimuli = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    fixations = pysaliency.FixationTrains.from_fixation_trains(
+        [[1, 2, 3], [4, 8]],
+        [[5, 6, 7], [9, 2]],
+        [[0, 1, 2], [0, 1]],
+        [0, 1],
+        [0, 1],
+    )
+    model = CrossvalidatedBaselineModel(stimuli, fixations, bandwidth=0.1)
+    path = tmp_path / 'cv_baseline_no_stimuli.hdf5'
+    model.to_hdf5(path, include_stimuli=False)
+
+    loaded = pysaliency.read_hdf5(str(path), stimuli=stimuli)
+    assert loaded.stimuli is stimuli
+
+    # Second call with a different stimuli object — must not return the cached first result
+    stimuli2 = pysaliency.Stimuli([np.random.randn(20, 20, 3), np.random.randn(20, 20, 3)])
+    loaded2 = pysaliency.read_hdf5(str(path), stimuli=stimuli2)
+    assert loaded2.stimuli is stimuli2
+    np.testing.assert_allclose(loaded2.log_density(stimuli2[0]), CrossvalidatedBaselineModel(stimuli2, fixations, bandwidth=0.1).log_density(stimuli2[0]))


### PR DESCRIPTION
 ## Summary

  - Adds `to_hdf5` / `read_hdf5` to both `BaselineModel` and `CrossvalidatedBaselineModel` — serializes model parameters rather than predictions, producing compact files for fast-to-compute models
  - Refactors `CrossvalidatedBaselineModel` to store `fixations_n` (integer array) instead of the full `fixations` object; removes the unused `shape_cache`
  - `CrossvalidatedBaselineModel.to_hdf5` supports `include_stimuli=True` (default, self-contained) or `False` (caller supplies `stimuli=` on reload, useful for large in-memory stimuli)
  - Adds a unified `pysaliency.read_hdf5` dispatcher that handles both datasets and models, with `**kwargs` passthrough for model-specific options like `stimuli=`