### PR TITLE
CI: add Python 3.12/3.13, update action versions

### DIFF
--- a/.github/workflows/test-package-conda.yml
+++ b/.github/workflows/test-package-conda.yml
@@ -61,11 +61,12 @@ jobs:
       shell: bash -el {0}
       run: |
         conda install pytest hypothesis
-        python setup.py build_ext --inplace
+        pip install -e .
         python -m pytest --nomatlab --notheano --nodownload tests
     - name: test build and install
       shell: bash -el {0}
       run: |
-        python setup.py sdist
+        pip install build
+        python -m build --sdist
         pip install dist/*.tar.gz
         mkdir tmp && cd tmp && python -c "import pysaliency"

--- a/.github/workflows/test-package-conda.yml
+++ b/.github/workflows/test-package-conda.yml
@@ -12,9 +12,11 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
+        - "3.13"
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         channels: conda-forge


### PR DESCRIPTION
- Add Python 3.12 and 3.13 to test matrix
- Update actions/checkout v2 → v4
- Update setup-miniconda v2 → v3